### PR TITLE
fix: Notify personalisation bug

### DIFF
--- a/api/.jest/setEnvVars.ts
+++ b/api/.jest/setEnvVars.ts
@@ -1,4 +1,5 @@
 process.env.CNI_TEMPLATE_ID = "5678";
 process.env.NODE_ENV = "test";
-process.env.NOTIFY_TEMPLATE_STANDARD = "1234";
+process.env.NOTIFY_TEMPLATE_USER_CONFIRMATION = "1234";
+process.env.NOTIFY_TEMPLATE_POST_NOTIFICATION = "1234";
 process.env.NOTIFY_API_KEY = "1234";

--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -7,5 +7,6 @@
   "submissionEmail": "SUBMISSION_EMAIL_ADDRESS",
   "senderEmail": "SENDER_EMAIL_ADDRESS",
   "notifyApiKey": "NOTIFY_API_KEY",
-  "notifyTemplateStandard": "NOTIFY_TEMPLATE_STANDARD"
+  "notifyTemplateUserConfirmation": "NOTIFY_TEMPLATE_USER_CONFIRMATION",
+  "notifyTemplatePostNotification": "NOTIFY_TEMPLATE_POST_NOTIFICATION"
 }

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -11,5 +11,6 @@ module.exports = {
   submissionAddress: "pye@cautionyourblast.com",
   senderEmail: "pye@cautionyourblast.com",
   notifyApiKey: "",
-  notifyTemplateStandard: "",
+  notifyTemplateUserConfirmation: "",
+  notifyTemplatePostNotification: "",
 };

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -85,11 +85,11 @@ export class NotifyService implements EmailServiceProvider {
       ...(additionalContexts[post as string] ?? {}),
     };
     const toPersonalisation = this.mapPersonalisationValues(personalisationValues);
-    return Object.entries(template).reduce(toPersonalisation, {});
+    return Object.entries(template).reduce(toPersonalisation, template);
   }
 
   mapPersonalisationValues(personalisationValues: Record<string, string | boolean>) {
-    return function (acc: Record<string, string | boolean | undefined>, [key, value]) {
+    return function (acc: NotifyPersonalisation, [key, value]) {
       return {
         ...acc,
         [key]: personalisationValues[key] ?? value,

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -70,7 +70,7 @@ export class NotifyService implements EmailServiceProvider {
     };
   }
 
-  getPersonalisationForTemplate(answers: AnswersHashMap, reference: string, paid: boolean, template: Record<string, string | boolean>) {
+  getPersonalisationForTemplate(answers: AnswersHashMap, reference: string, paid: boolean, template: Record<string, string | boolean | undefined>) {
     const docsList = this.buildDocsList(answers, paid);
     const country = answers["country"];
     const post = answers["post"];
@@ -82,12 +82,17 @@ export class NotifyService implements EmailServiceProvider {
       ...(additionalContexts[country as string] ?? {}),
       ...(additionalContexts[post as string] ?? {}),
     };
-    return Object.keys(template).reduce((acc, curr) => {
+    const mapPersonalisationValuesToKeys = this.mapPersonalisationValues(personalisationValues);
+    return Object.entries(template).reduce(mapPersonalisationValuesToKeys, {});
+  }
+
+  mapPersonalisationValues(personalisationValues: Record<string, string | boolean>) {
+    return function (acc: Record<string, string | boolean | undefined>, [key, value]) {
       return {
         ...acc,
-        [curr]: personalisationValues[curr],
+        [key]: personalisationValues[key] ?? value,
       };
-    }, {});
+    };
   }
 
   handleError(error: any) {

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -3,7 +3,7 @@ import config from "config";
 import pino, { Logger } from "pino";
 import { ApplicationError } from "../../../ApplicationError";
 import * as additionalContexts from "./additionalContexts.json";
-import { EmailServiceProvider, isUserEmailTemplate, NotifySendEmailArgs, UserEmailTemplate } from "./types";
+import { EmailServiceProvider, isNotifyEmailTemplate, NotifyPersonalisation, NotifySendEmailArgs, NotifyEmailTemplate } from "./types";
 import * as templates from "./templates";
 import { FormField } from "../../../types/FormField";
 import { answersHashMap } from "../helpers";
@@ -19,25 +19,27 @@ const previousMarriageDocs = {
 export class NotifyService implements EmailServiceProvider {
   notify: NotifyClient;
   logger: Logger;
-  templates: Record<UserEmailTemplate, string>;
+  templates: Record<NotifyEmailTemplate, string>;
   constructor() {
     const apiKey = config.get("notifyApiKey");
-    const standardTemplate = config.get("notifyTemplateStandard");
+    const userConfirmationTemplate = config.get("notifyTemplateUserConfirmation");
+    const postNotificationTemplate = config.get("notifyTemplatePostNotification");
     if (!apiKey) {
       throw new ApplicationError("NOTIFY", "NO_API_KEY", 500);
     }
-    if (!standardTemplate) {
+    if (!userConfirmationTemplate || !postNotificationTemplate) {
       throw new ApplicationError("NOTIFY", "NO_TEMPLATE", 500);
     }
     this.templates = {
-      standard: standardTemplate as string,
+      userConfirmation: userConfirmationTemplate as string,
+      postNotification: postNotificationTemplate as string,
     };
     this.notify = new NotifyClient(apiKey as string);
     this.logger = pino().child({ service: "Notify" });
   }
 
   async send(fields: FormField[], template: string, reference: string) {
-    if (!isUserEmailTemplate(template)) {
+    if (!isNotifyEmailTemplate(template)) {
       throw new ApplicationError("NOTIFY", "TEMPLATE_NOT_FOUND", 400);
     }
     const emailArgs = this.buildSendEmailArgs(fields, template, reference);
@@ -56,12 +58,12 @@ export class NotifyService implements EmailServiceProvider {
     }
   }
 
-  buildSendEmailArgs(fields: FormField[], template: UserEmailTemplate, reference: string): NotifySendEmailArgs {
+  buildSendEmailArgs(fields: FormField[], template: NotifyEmailTemplate, reference: string): NotifySendEmailArgs {
     const answers = answersHashMap(fields);
-    const defaultTemplate = templates.user[template];
+    const defaultTemplate = templates.notify[template];
     const personalisation = this.getPersonalisationForTemplate(answers, reference, answers.paid as boolean, defaultTemplate);
     return {
-      template: this.templates.standard,
+      template: this.templates.userConfirmation,
       emailAddress: answers.emailAddress as string,
       options: {
         personalisation,
@@ -70,7 +72,7 @@ export class NotifyService implements EmailServiceProvider {
     };
   }
 
-  getPersonalisationForTemplate(answers: AnswersHashMap, reference: string, paid: boolean, template: Record<string, string | boolean | undefined>) {
+  getPersonalisationForTemplate(answers: AnswersHashMap, reference: string, paid: boolean, template: NotifyPersonalisation) {
     const docsList = this.buildDocsList(answers, paid);
     const country = answers["country"];
     const post = answers["post"];
@@ -82,8 +84,8 @@ export class NotifyService implements EmailServiceProvider {
       ...(additionalContexts[country as string] ?? {}),
       ...(additionalContexts[post as string] ?? {}),
     };
-    const mapPersonalisationValuesToKeys = this.mapPersonalisationValues(personalisationValues);
-    return Object.entries(template).reduce(mapPersonalisationValuesToKeys, {});
+    const toPersonalisation = this.mapPersonalisationValues(personalisationValues);
+    return Object.entries(template).reduce(toPersonalisation, {});
   }
 
   mapPersonalisationValues(personalisationValues: Record<string, string | boolean>) {

--- a/api/src/middlewares/services/EmailService/SESService.ts
+++ b/api/src/middlewares/services/EmailService/SESService.ts
@@ -23,8 +23,8 @@ export class SESService implements EmailServiceProvider {
     this.ses = ses;
     this.fileService = fileService;
     this.templates = {
-      affirmation: SESService.createTemplate(templates.staff.affirmation),
-      cni: SESService.createTemplate(templates.staff.affirmation),
+      affirmation: SESService.createTemplate(templates.ses.affirmation),
+      cni: SESService.createTemplate(templates.ses.affirmation),
     };
   }
 

--- a/api/src/middlewares/services/EmailService/__tests__/NotifyService.test.ts
+++ b/api/src/middlewares/services/EmailService/__tests__/NotifyService.test.ts
@@ -1,20 +1,19 @@
 import { NotifyService } from "../NotifyService";
 import { flattenQuestions, answersHashMap } from "../../helpers";
 import { testData } from "./fixtures";
-import { standard } from "../templates/user";
+import { userConfirmation } from "../templates/notify";
 
 const emailService = new NotifyService();
 const formFields = [{ key: "paid", type: "TextField", title: "paid", answer: true }, ...flattenQuestions(testData.questions)];
 
 test("buildSendEmailArgs should return the correct personalisation", () => {
-  const emailParams = emailService.buildSendEmailArgs(formFields, "standard", "1234");
+  const emailParams = emailService.buildSendEmailArgs(formFields, "userConfirmation", "1234");
 
   expect(emailParams).toEqual({
     template: "1234",
     emailAddress: "test@test.com",
     options: {
       personalisation: {
-        oathType: "affirmation",
         firstName: "foo",
         post: "Istanbul Consulate General",
         docsList:
@@ -32,9 +31,8 @@ test("buildSendEmailArgs should return the correct personalisation", () => {
 });
 
 test("mapPersonalisationValues should return some keys as undefined if a required value is missing", () => {
-  const template = standard;
+  const template = userConfirmation;
   const values = {
-    oathType: "Affirmation",
     firstName: "Joe",
     docsList: "* Document 1\n* Document 2",
     reference: "ABC1234",
@@ -43,7 +41,7 @@ test("mapPersonalisationValues should return some keys as undefined if a require
   };
   const mapPersonalisationValuesFunc = emailService.mapPersonalisationValues(values);
   const result = Object.entries(template).reduce(mapPersonalisationValuesFunc, {});
-  expect(result.post).toBe(undefined);
+  expect(result["post"]).toBe(undefined);
 });
 
 test("buildDocsList will add optional documents when the relevant fields are filled in", () => {

--- a/api/src/middlewares/services/EmailService/__tests__/NotifyService.test.ts
+++ b/api/src/middlewares/services/EmailService/__tests__/NotifyService.test.ts
@@ -1,6 +1,7 @@
 import { NotifyService } from "../NotifyService";
 import { flattenQuestions, answersHashMap } from "../../helpers";
 import { testData } from "./fixtures";
+import { standard } from "../templates/user";
 
 const emailService = new NotifyService();
 const formFields = [{ key: "paid", type: "TextField", title: "paid", answer: true }, ...flattenQuestions(testData.questions)];
@@ -22,11 +23,27 @@ test("buildSendEmailArgs should return the correct personalisation", () => {
         translationNeeded: false,
         bookingLink: "",
         country: "Turkey",
-        additionalText: undefined,
+        additionalText: "",
+        localRequirements: "",
       },
       reference: "1234",
     },
   });
+});
+
+test("mapPersonalisationValues should return some keys as undefined if a required value is missing", () => {
+  const template = standard;
+  const values = {
+    oathType: "Affirmation",
+    firstName: "Joe",
+    docsList: "* Document 1\n* Document 2",
+    reference: "ABC1234",
+    country: "Turkey",
+    bookingLink: "https://a-booking-link.com",
+  };
+  const mapPersonalisationValuesFunc = emailService.mapPersonalisationValues(values);
+  const result = Object.entries(template).reduce(mapPersonalisationValuesFunc, {});
+  expect(result.post).toBe(undefined);
 });
 
 test("buildDocsList will add optional documents when the relevant fields are filled in", () => {

--- a/api/src/middlewares/services/EmailService/templates/index.ts
+++ b/api/src/middlewares/services/EmailService/templates/index.ts
@@ -1,2 +1,2 @@
-export * as staff from "./staff";
-export * as user from "./user";
+export * as ses from "./ses";
+export * as notify from "./notify";

--- a/api/src/middlewares/services/EmailService/templates/notify/index.ts
+++ b/api/src/middlewares/services/EmailService/templates/notify/index.ts
@@ -1,0 +1,2 @@
+export { userConfirmation } from "./userConfirmation";
+export { postNotification } from "./postNotification";

--- a/api/src/middlewares/services/EmailService/templates/notify/postNotification.ts
+++ b/api/src/middlewares/services/EmailService/templates/notify/postNotification.ts
@@ -1,0 +1,3 @@
+export const postNotification = {
+  post: undefined,
+};

--- a/api/src/middlewares/services/EmailService/templates/notify/userConfirmation.ts
+++ b/api/src/middlewares/services/EmailService/templates/notify/userConfirmation.ts
@@ -1,5 +1,4 @@
-export const standard = {
-  oathType: undefined,
+export const userConfirmation = {
   firstName: undefined,
   post: undefined,
   docsList: "",

--- a/api/src/middlewares/services/EmailService/templates/ses/affirmation.ts
+++ b/api/src/middlewares/services/EmailService/templates/ses/affirmation.ts
@@ -1,0 +1,8 @@
+const template = `<ul>
+    {{#each questions}}
+        <li>{{this.title}}: {{this.answer}}</li>
+    {{/each}}
+</ul>
+`;
+
+export default template;

--- a/api/src/middlewares/services/EmailService/templates/ses/index.ts
+++ b/api/src/middlewares/services/EmailService/templates/ses/index.ts
@@ -1,0 +1,3 @@
+import affirmation from "./affirmation";
+
+export { affirmation };

--- a/api/src/middlewares/services/EmailService/templates/user/index.ts
+++ b/api/src/middlewares/services/EmailService/templates/user/index.ts
@@ -1,1 +1,0 @@
-export { standard } from "./standard";

--- a/api/src/middlewares/services/EmailService/templates/user/standard.ts
+++ b/api/src/middlewares/services/EmailService/templates/user/standard.ts
@@ -1,11 +1,12 @@
 export const standard = {
-  oathType: "",
-  firstName: "",
-  post: "",
+  oathType: undefined,
+  firstName: undefined,
+  post: undefined,
   docsList: "",
-  reference: "",
+  reference: undefined,
   additionalText: "",
-  country: "",
-  bookingLink: "",
+  country: undefined,
+  bookingLink: undefined,
   translationNeeded: false,
+  localRequirements: "",
 };

--- a/api/src/middlewares/services/EmailService/types.ts
+++ b/api/src/middlewares/services/EmailService/types.ts
@@ -1,5 +1,6 @@
 import { SendEmailOptions } from "notifications-node-client";
 import { FormField } from "../../../types/FormField";
+import { notify } from "./templates";
 
 export interface NotifySendEmailArgs {
   template: string;
@@ -13,9 +14,11 @@ export function isStaffEmailTemplate(template: string): template is StaffEmailTe
   return template === "affirmation" || template === "cni";
 }
 
-export type UserEmailTemplate = "standard";
+export type NotifyEmailTemplate = "userConfirmation" | "postNotification";
 
-export function isUserEmailTemplate(template: string): template is UserEmailTemplate {
+export type NotifyPersonalisation = typeof notify.userConfirmation | typeof notify.postNotification;
+
+export function isNotifyEmailTemplate(template: string): template is NotifyEmailTemplate {
   return template === "standard";
 }
 

--- a/api/src/middlewares/services/SubmitService/SubmitService.ts
+++ b/api/src/middlewares/services/SubmitService/SubmitService.ts
@@ -41,7 +41,7 @@ export class SubmitService {
 
     const staffPromise = this.staffEmailService.send(formFields, "affirmation", reference);
 
-    const customerPromise = this.customerEmailService.send(formFields, "standard", reference);
+    const customerPromise = this.customerEmailService.send(formFields, "userConfirmation", reference);
 
     const [staffRes, customerRes] = await Promise.all([staffPromise, customerPromise]);
 


### PR DESCRIPTION
Previously if any optional personalisation values weren't present, the personalisation property would be set to undefined. This would cause it to fail validation from notify, as notify expects an empty string or false value, but not undefined.

Now default personalisation values are passed through from the template, meaning that required fields will still need to be present, but optional values will be set to the default value if no value is present.