### PR TITLE
Feat/enqueue-notify-emails

### DIFF
--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -8,5 +8,10 @@
   "senderEmail": "SENDER_EMAIL_ADDRESS",
   "notifyApiKey": "NOTIFY_API_KEY",
   "notifyTemplateUserConfirmation": "NOTIFY_TEMPLATE_USER_CONFIRMATION",
-  "notifyTemplatePostNotification": "NOTIFY_TEMPLATE_POST_NOTIFICATION"
+  "notifyTemplatePostNotification": "NOTIFY_TEMPLATE_POST_NOTIFICATION",
+  "Queue": {
+    "url": "QUEUE_URL",
+    "archiveFailedAfterDays": "ARCHIVE_FAILED_AFTER_DAYS",
+    "deleteArchivedAfterDays": "DELETE_ARCHIVED_IN_DAYS"
+  }
 }

--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -8,8 +8,8 @@
   "senderEmail": "SENDER_EMAIL_ADDRESS",
   "Notify": {
     "Template": {
-      "UserConfirmation": "NOTIFY_TEMPLATE_USER_CONFIRMATION",
-      "PostNotification": "NOTIFY_TEMPLATE_POST_NOTIFICATION"
+      "userConfirmation": "NOTIFY_TEMPLATE_USER_CONFIRMATION",
+      "postNotification": "NOTIFY_TEMPLATE_POST_NOTIFICATION"
     }
   },
   "Queue": {

--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -6,9 +6,12 @@
   "cniTemplate": "CNI_TEMPLATE_ID",
   "submissionEmail": "SUBMISSION_EMAIL_ADDRESS",
   "senderEmail": "SENDER_EMAIL_ADDRESS",
-  "notifyApiKey": "NOTIFY_API_KEY",
-  "notifyTemplateUserConfirmation": "NOTIFY_TEMPLATE_USER_CONFIRMATION",
-  "notifyTemplatePostNotification": "NOTIFY_TEMPLATE_POST_NOTIFICATION",
+  "Notify": {
+    "Template": {
+      "UserConfirmation": "NOTIFY_TEMPLATE_USER_CONFIRMATION",
+      "PostNotification": "NOTIFY_TEMPLATE_POST_NOTIFICATION"
+    },
+  },
   "Queue": {
     "url": "QUEUE_URL",
     "archiveFailedAfterDays": "ARCHIVE_FAILED_AFTER_DAYS",

--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -10,7 +10,7 @@
     "Template": {
       "UserConfirmation": "NOTIFY_TEMPLATE_USER_CONFIRMATION",
       "PostNotification": "NOTIFY_TEMPLATE_POST_NOTIFICATION"
-    },
+    }
   },
   "Queue": {
     "url": "QUEUE_URL",

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -13,4 +13,7 @@ module.exports = {
   notifyApiKey: "",
   notifyTemplateUserConfirmation: "",
   notifyTemplatePostNotification: "",
+  Queue: {
+    url: "",
+  },
 };

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -11,6 +11,6 @@ module.exports = {
   submissionAddress: "pye@cautionyourblast.com",
   senderEmail: "pye@cautionyourblast.com",
   Queue: {
-    url: "",
+    url: "postgresql://user:root@localhost:5432/queue",
   },
 };

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -10,9 +10,6 @@ module.exports = {
   documentPassword: "Sup3rS3cr3tP4ssw0rd",
   submissionAddress: "pye@cautionyourblast.com",
   senderEmail: "pye@cautionyourblast.com",
-  notifyApiKey: "",
-  notifyTemplateUserConfirmation: "",
-  notifyTemplatePostNotification: "",
   Queue: {
     url: "",
   },

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
     "mimetext": "^3.0.16",
     "nanoid": "3.3.4",
     "notifications-node-client": "^8.0.0",
+    "pg-boss": "^9.0.3",
     "pino": "^8.15.4",
     "pino-http": "^8.5.0",
     "typescript": "^5.2.2"

--- a/api/src/errors.ts
+++ b/api/src/errors.ts
@@ -33,7 +33,7 @@ type SESErrorCode =
   | "BAD_REQUEST"
   | "API_ERROR"
   | "UNKNOWN";
-type NotifyErrorCode = "NO_API_KEY" | "MISSING_TEMPLATE" | "UNKNOWN";
+type NotifyErrorCode = "NO_API_KEY" | "MISSING_TEMPLATE" | "QUEUE_ERROR" | "UNKNOWN";
 
 type GenericErrorCode = "UNKNOWN" | "RATE_LIMIT_EXCEEDED";
 
@@ -74,7 +74,8 @@ const SES: ErrorRecord<SESErrorCode> = {
 const NOTIFY: ErrorRecord<NotifyErrorCode> = {
   NO_API_KEY: "No Notify API key has been set",
   MISSING_TEMPLATE: "A notify template id has not been set",
-  UNKNOWN: "There waa an unknown error sending the email",
+  UNKNOWN: "There was an unknown error sending the email",
+  QUEUE_ERROR: "There was an error sending this email to queue",
 };
 
 const GENERIC: ErrorRecord<GenericErrorCode> = {

--- a/api/src/errors.ts
+++ b/api/src/errors.ts
@@ -33,7 +33,7 @@ type SESErrorCode =
   | "BAD_REQUEST"
   | "API_ERROR"
   | "UNKNOWN";
-type NotifyErrorCode = "NO_API_KEY" | "MISSING_TEMPLATE" | "QUEUE_ERROR" | "UNKNOWN";
+type NotifyErrorCode = "QUEUE_ERROR" | "UNKNOWN";
 
 type GenericErrorCode = "UNKNOWN" | "RATE_LIMIT_EXCEEDED";
 
@@ -72,8 +72,6 @@ const SES: ErrorRecord<SESErrorCode> = {
 };
 
 const NOTIFY: ErrorRecord<NotifyErrorCode> = {
-  NO_API_KEY: "No Notify API key has been set",
-  MISSING_TEMPLATE: "A notify template id has not been set",
   UNKNOWN: "There was an unknown error sending the email",
   QUEUE_ERROR: "There was an error sending this email to queue",
 };

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -31,7 +31,7 @@ export class NotifyService implements EmailServiceProvider {
         postNotification,
       };
     } catch (err) {
-      this.logger.error({ err }, "No template has been configured, exiting");
+      this.logger.error({ err }, "Notify templates have not been configured, exiting");
       process.exit(1);
     }
 

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -25,7 +25,7 @@ export class NotifyService implements EmailServiceProvider {
 
     try {
       const userConfirmation = config.get<string>("Notify.Template.UserConfirmation");
-      const postNotification = config.get<string>("NotifyTemplate.PostNotification");
+      const postNotification = config.get<string>("Notify.Template.PostNotification");
       this.templates = {
         userConfirmation,
         postNotification,

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -24,8 +24,8 @@ export class NotifyService implements EmailServiceProvider {
     this.logger = pino().child({ service: "Notify" });
 
     try {
-      const userConfirmation = config.get<string>("Notify.Template.UserConfirmation");
-      const postNotification = config.get<string>("Notify.Template.PostNotification");
+      const userConfirmation = config.get<string>("Notify.Template.userConfirmation");
+      const postNotification = config.get<string>("Notify.Template.postNotification");
       this.templates = {
         userConfirmation,
         postNotification,

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -106,16 +106,6 @@ export class NotifyService implements EmailServiceProvider {
     };
   }
 
-  handleError(error: any) {
-    const { response = {} } = error;
-    const isNotifyError = "data" in response && response.data.errors;
-    if (isNotifyError) {
-      const notifyErrors = response.data.errors as RequestError[];
-      throw new ApplicationError("NOTIFY", "API_ERROR", 500, JSON.stringify(notifyErrors));
-    }
-    throw new ApplicationError("NOTIFY", "UNKNOWN", 500, error.message);
-  }
-
   buildDocsList(fields: AnswersHashMap, paid: boolean) {
     const docsList = ["your UK passport", "proof of address", "your partner’s passport or national identity card"];
     if (fields.maritalStatus && fields.maritalStatus !== "Never married") {

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -3,7 +3,7 @@ import config from "config";
 import pino, { Logger } from "pino";
 import { ApplicationError } from "../../../ApplicationError";
 import * as additionalContexts from "./additionalContexts.json";
-import { EmailServiceProvider, NotifyPersonalisation, NotifySendEmailArgs, NotifyEmailTemplate, EmailTemplate } from "./types";
+import { EmailServiceProvider, NotifyPersonalisation, NotifySendEmailArgs, NotifyEmailTemplate } from "./types";
 import * as templates from "./templates";
 import { FormField } from "../../../types/FormField";
 import { answersHashMap } from "../helpers";

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -1,4 +1,4 @@
-import { NotifyClient, RequestError } from "notifications-node-client";
+import { NotifyClient } from "notifications-node-client";
 import config from "config";
 import pino, { Logger } from "pino";
 import { ApplicationError } from "../../../ApplicationError";

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -64,7 +64,7 @@ export class NotifyService implements EmailServiceProvider {
           retryBackoff: true,
         },
       });
-      this.logger.info({ reference, jobId }, `reference ${reference}, notify email queued with jobId ${jobId}`);
+      this.logger.info({ reference, emailAddress, jobId }, `reference ${reference}, notify email queued with jobId ${jobId}`);
     } catch (e: any) {
       this.logger.error({ err: e, reference, emailAddress }, `Sending ${template} to ${emailAddress} failed`);
       throw new ApplicationError("NOTIFY", "QUEUE_ERROR", 500, e.message);
@@ -127,6 +127,7 @@ export class NotifyService implements EmailServiceProvider {
       docsList.push("religious book of your faith to swear upon");
     }
     if (!paid) {
+      // TODO:- update to reflect correct £.
       docsList.push("the equivalent of £50 in the local currency");
     }
     const country = fields.country as string;

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -24,8 +24,8 @@ export class NotifyService implements EmailServiceProvider {
   queue: PgBoss;
   constructor() {
     const apiKey = config.get("notifyApiKey");
-    const userConfirmationTemplate = config.get("notifyTemplateUserConfirmation");
-    const postNotificationTemplate = config.get("notifyTemplatePostNotification");
+    const userConfirmationTemplate = config.get<string>("notifyTemplateUserConfirmation");
+    const postNotificationTemplate = config.get<string>("notifyTemplatePostNotification");
     if (!apiKey) {
       throw new ApplicationError("NOTIFY", "NO_API_KEY", 500);
     }
@@ -33,8 +33,8 @@ export class NotifyService implements EmailServiceProvider {
       throw new ApplicationError("NOTIFY", "NO_TEMPLATE", 500);
     }
     this.templates = {
-      userConfirmation: userConfirmationTemplate as string,
-      postNotification: postNotificationTemplate as string,
+      userConfirmation: userConfirmationTemplate,
+      postNotification: postNotificationTemplate,
     };
     this.notify = new NotifyClient(apiKey as string);
     this.logger = pino().child({ service: "Notify" });

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -24,8 +24,8 @@ export class NotifyService implements EmailServiceProvider {
     this.logger = pino().child({ service: "Notify" });
 
     try {
-      const userConfirmation = config.get<string>("notifyTemplateUserConfirmation");
-      const postNotification = config.get<string>("notifyTemplatePostNotification");
+      const userConfirmation = config.get<string>("Notify.Template.UserConfirmation");
+      const postNotification = config.get<string>("NotifyTemplate.PostNotification");
       this.templates = {
         userConfirmation,
         postNotification,

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -1,4 +1,3 @@
-import { NotifyClient } from "notifications-node-client";
 import config from "config";
 import pino, { Logger } from "pino";
 import { ApplicationError } from "../../../ApplicationError";
@@ -18,7 +17,6 @@ const previousMarriageDocs = {
   Annulled: "decree of nullity",
 };
 export class NotifyService implements EmailServiceProvider {
-  notify: NotifyClient;
   logger: Logger;
   templates: Record<NotifyEmailTemplate, string>;
   queue?: PgBoss;
@@ -36,7 +34,6 @@ export class NotifyService implements EmailServiceProvider {
       userConfirmation: userConfirmationTemplate,
       postNotification: postNotificationTemplate,
     };
-    this.notify = new NotifyClient(apiKey);
     this.logger = pino().child({ service: "Notify" });
     const queue = new PgBoss({
       connectionString: config.get<string>("Queue.url"),

--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -3,7 +3,7 @@ import config from "config";
 import pino, { Logger } from "pino";
 import { ApplicationError } from "../../../ApplicationError";
 import * as additionalContexts from "./additionalContexts.json";
-import { EmailServiceProvider, NotifyPersonalisation, NotifySendEmailArgs, NotifyEmailTemplate } from "./types";
+import { EmailServiceProvider, NotifyPersonalisation, NotifySendEmailArgs, NotifyEmailTemplate, EmailTemplate } from "./types";
 import * as templates from "./templates";
 import { FormField } from "../../../types/FormField";
 import { answersHashMap } from "../helpers";

--- a/api/src/middlewares/services/EmailService/SESService.ts
+++ b/api/src/middlewares/services/EmailService/SESService.ts
@@ -11,13 +11,11 @@ import { createMimeMessage } from "mimetext";
 import config from "config";
 import { FileService } from "../FileService";
 import { getFileFields, answersHashMap } from "../helpers";
-import PgBoss from "pg-boss";
 export class SESService implements EmailServiceProvider {
   logger: Logger;
   ses: SESClient;
   fileService: FileService;
   templates: Record<SESEmailTemplate, HandlebarsTemplateDelegate>;
-  queue: PgBoss;
 
   constructor({ fileService }) {
     this.logger = logger().child({ service: "SES" });
@@ -27,10 +25,6 @@ export class SESService implements EmailServiceProvider {
       affirmation: SESService.createTemplate(templates.ses.affirmation),
       cni: SESService.createTemplate(templates.ses.affirmation),
     };
-
-    this.queue = new PgBoss({
-      connectionString: config.get<string>("Queue.url"),
-    });
   }
 
   async send(fields: FormField[], template: string, reference: string) {

--- a/api/src/middlewares/services/EmailService/SESService.ts
+++ b/api/src/middlewares/services/EmailService/SESService.ts
@@ -11,12 +11,13 @@ import { createMimeMessage } from "mimetext";
 import config from "config";
 import { FileService } from "../FileService";
 import { getFileFields, answersHashMap } from "../helpers";
-
+import PgBoss from "pg-boss";
 export class SESService implements EmailServiceProvider {
   logger: Logger;
   ses: SESClient;
   fileService: FileService;
   templates: Record<SESEmailTemplate, HandlebarsTemplateDelegate>;
+  queue: PgBoss;
 
   constructor({ fileService }) {
     this.logger = logger().child({ service: "SES" });
@@ -26,6 +27,10 @@ export class SESService implements EmailServiceProvider {
       affirmation: SESService.createTemplate(templates.ses.affirmation),
       cni: SESService.createTemplate(templates.ses.affirmation),
     };
+
+    this.queue = new PgBoss({
+      connectionString: config.get<string>("Queue.url"),
+    });
   }
 
   async send(fields: FormField[], template: string, reference: string) {

--- a/api/src/middlewares/services/EmailService/types.ts
+++ b/api/src/middlewares/services/EmailService/types.ts
@@ -19,5 +19,5 @@ export type NotifyEmailTemplate = "userConfirmation" | "postNotification";
 export type NotifyPersonalisation = typeof notify.userConfirmation | typeof notify.postNotification;
 
 export interface EmailServiceProvider {
-  send: (fields: FormField[], template: NotifyEmailTemplate & SESEmailTemplate, reference: string) => Promise<any>;
+  send: (fields: FormField[], template: NotifyEmailTemplate | SESEmailTemplate, reference: string) => Promise<any>;
 }

--- a/api/src/middlewares/services/EmailService/types.ts
+++ b/api/src/middlewares/services/EmailService/types.ts
@@ -15,9 +15,10 @@ export function isSESEmailTemplate(template: string): template is SESEmailTempla
 }
 
 export type NotifyEmailTemplate = "userConfirmation" | "postNotification";
+export type EmailTemplate = SESEmailTemplate & NotifyEmailTemplate;
 
 export type NotifyPersonalisation = typeof notify.userConfirmation | typeof notify.postNotification;
 
 export interface EmailServiceProvider {
-  send: (fields: FormField[], template: NotifyEmailTemplate | SESEmailTemplate, reference: string) => Promise<any>;
+  send: (fields: FormField[], template: EmailTemplate, reference: string) => Promise<any>;
 }

--- a/api/src/middlewares/services/EmailService/types.ts
+++ b/api/src/middlewares/services/EmailService/types.ts
@@ -18,10 +18,6 @@ export type NotifyEmailTemplate = "userConfirmation" | "postNotification";
 
 export type NotifyPersonalisation = typeof notify.userConfirmation | typeof notify.postNotification;
 
-export function isNotifyEmailTemplate(template: string): template is NotifyEmailTemplate {
-  return template === "standard";
-}
-
 export interface EmailServiceProvider {
-  send: (fields: FormField[], template: string, reference: string) => Promise<any>;
+  send: (fields: FormField[], template: NotifyEmailTemplate & SESEmailTemplate, reference: string) => Promise<any>;
 }

--- a/api/src/middlewares/services/SubmitService/SubmitService.ts
+++ b/api/src/middlewares/services/SubmitService/SubmitService.ts
@@ -2,15 +2,15 @@ import logger, { Logger } from "pino";
 import { FileService } from "../FileService";
 import { FormDataBody } from "../../../types";
 import { flattenQuestions } from "../helpers";
-import { EmailServiceProvider } from "../EmailService/types";
+import { NotifyService, SESService } from "../EmailService";
 const { customAlphabet } = require("nanoid");
 
 const nanoid = customAlphabet("1234567890ABCDEFGHIJKLMNPQRSTUVWXYZ-_", 10);
 export class SubmitService {
   logger: Logger;
   fileService: FileService;
-  customerEmailService: EmailServiceProvider;
-  staffEmailService: EmailServiceProvider;
+  customerEmailService: NotifyService;
+  staffEmailService: SESService;
 
   constructor({ fileService, notifyService, sesService }) {
     this.logger = logger().child({ service: "Submit" });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       context: .
       dockerfile: api/Dockerfile
   worker:
+    environment:
+      - NOTIFY_API_KEY=${NOTIFY_API_KEY:?}
     build:
       context: .
       dockerfile: worker/Dockerfile

--- a/worker/config/custom-environment-variables.json
+++ b/worker/config/custom-environment-variables.json
@@ -1,5 +1,8 @@
 {
   "Queue": {
     "url": "QUEUE_URL"
+  },
+  "Notify": {
+    "apiKey": "NOTIFY_API_KEY"
   }
 }

--- a/worker/package.json
+++ b/worker/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "axios": "^1.6.5",
     "config": "^3.3.9",
+    "notifications-node-client": "^8.0.0",
     "pg-boss": "^9.0.3",
     "pino": "^8.17.2"
   }

--- a/worker/src/queues/notify/workers/notifyHandler.ts
+++ b/worker/src/queues/notify/workers/notifyHandler.ts
@@ -1,7 +1,7 @@
 import pino from "pino";
 import { Job } from "pg-boss";
 import config from "config";
-import { NotifyClient, RequestError, SendEmailOptions, SendEmailResponse } from "notifications-node-client";
+import { NotifyClient, SendEmailOptions, SendEmailResponse } from "notifications-node-client";
 
 const queue = "notifications";
 const worker = "notify";
@@ -43,15 +43,8 @@ export async function notifyHandler(job: Job<NotifyJob>) {
     }
 
     if (e.request) {
-      logger.error(jobId, `post to ${url} request could not be sent, see database for error`);
+      logger.error(jobId, `Request could not be sent to Notify`);
     }
-    /*if (!e.resonse)
-    const isNotifyError = "data" in response && response.data.errors;
-    if (isNotifyError) {
-      const notifyErrors = response.data.errors as RequestError[];
-      throw new ApplicationError("NOTIFY", "API_ERROR", 500, JSON.stringify(notifyErrors));
-    }
-throw new ApplicationError("NOTIFY", "UNKNOWN", 500, error.message);
-   */
+    throw e;
   }
 }

--- a/worker/src/queues/notify/workers/notifyHandler.ts
+++ b/worker/src/queues/notify/workers/notifyHandler.ts
@@ -3,7 +3,7 @@ import { Job } from "pg-boss";
 import config from "config";
 import { NotifyClient, SendEmailOptions, SendEmailResponse } from "notifications-node-client";
 
-const queue = "notifications";
+const queue = "notify";
 const worker = "notify";
 
 const logger = pino().child({
@@ -22,7 +22,7 @@ type NotifyJob = {
 };
 
 /**
- * When a "notifications" event is detected, this worker POSTs the data to `job.data.data.webhook_url`
+ * When a "notify" event is detected, this worker uses the GOV.UK Notify client to send the email.
  * The source of this event is the runner, after a user has submitted a form.
  */
 export async function notifyHandler(job: Job<NotifyJob>) {

--- a/worker/src/queues/notify/workers/notifyHandler.ts
+++ b/worker/src/queues/notify/workers/notifyHandler.ts
@@ -38,7 +38,7 @@ export async function notifyHandler(job: Job<NotifyJob>) {
     return id;
   } catch (e: any) {
     if (e.response) {
-      logger.error({ jobId, err: e.response.data.errors }, "Notify responded with an error");
+      logger.error({ jobId, err: e.response.data.errors, emailAddress }, "Notify responded with an error");
       throw e.response.data;
     }
 

--- a/worker/src/queues/notify/workers/notifyHandler.ts
+++ b/worker/src/queues/notify/workers/notifyHandler.ts
@@ -14,9 +14,11 @@ const logger = pino().child({
 const notifyClient = new NotifyClient(config.get<string>("Notify.apiKey"));
 
 type NotifyJob = {
-  template: string;
-  emailAddress: string;
-  options: SendEmailOptions<any>;
+  data: {
+    template: string;
+    emailAddress: string;
+    options: SendEmailOptions<any>;
+  };
 };
 
 /**
@@ -26,7 +28,7 @@ type NotifyJob = {
 export async function notifyHandler(job: Job<NotifyJob>) {
   const jobId = job.id;
   logger.info({ jobId }, `received ${worker} job`);
-  const { data } = job;
+  const { data } = job.data;
   const { template, emailAddress, options } = data;
   try {
     const response = await notifyClient.sendEmail(template, emailAddress, options);

--- a/worker/src/queues/notify/workers/notifyHandler.ts
+++ b/worker/src/queues/notify/workers/notifyHandler.ts
@@ -1,17 +1,47 @@
 import pino from "pino";
 import { Job } from "pg-boss";
+import config from "config";
+import { NotifyClient, RequestError, SendEmailOptions, SendEmailResponse } from "notifications-node-client";
 
 const queue = "notifications";
 const worker = "notify";
 
-const logger = pino();
-export const metadata = { queue, worker };
+const logger = pino().child({
+  queue,
+  worker,
+});
+
+const notifyClient = new NotifyClient(config.get<string>("Notify.apiKey"));
+
+type NotifyJob = {
+  template: string;
+  emailAddress: string;
+  options: SendEmailOptions<any>;
+};
 
 /**
  * When a "submission" event is detected, this worker POSTs the data to `job.data.data.webhook_url`
  * The source of this event is the runner, after a user has submitted a form.
  */
-export async function notifyHandler(job: Job) {
-  const jobLogData = { jobId: job.id, ...metadata };
-  logger.info(jobLogData, `received ${worker} job`);
+export async function notifyHandler(job: Job<NotifyJob>) {
+  const jobId = job.id;
+  logger.info({ jobId }, `received ${worker} job`);
+  const { data } = job;
+  const { template, emailAddress, options } = data;
+  try {
+    const response = await notifyClient.sendEmail(template, emailAddress, options);
+    const data = response.data as SendEmailResponse;
+    const { id, reference } = data;
+    logger.info({ jobId, reference, template }, "sent successfully");
+    return id;
+  } catch (e) {
+    /*if (!e.resonse)
+    const isNotifyError = "data" in response && response.data.errors;
+    if (isNotifyError) {
+      const notifyErrors = response.data.errors as RequestError[];
+      throw new ApplicationError("NOTIFY", "API_ERROR", 500, JSON.stringify(notifyErrors));
+    }
+throw new ApplicationError("NOTIFY", "UNKNOWN", 500, error.message);
+   */
+  }
 }

--- a/worker/src/queues/notify/workers/notifyHandler.ts
+++ b/worker/src/queues/notify/workers/notifyHandler.ts
@@ -36,7 +36,15 @@ export async function notifyHandler(job: Job<NotifyJob>) {
     const { id, reference } = data;
     logger.info({ jobId, reference, template }, "sent successfully");
     return id;
-  } catch (e) {
+  } catch (e: any) {
+    if (e.response) {
+      logger.error({ jobId, err: e.response.data.errors }, "Notify responded with an error");
+      throw e.response.data;
+    }
+
+    if (e.request) {
+      logger.error(jobId, `post to ${url} request could not be sent, see database for error`);
+    }
     /*if (!e.resonse)
     const isNotifyError = "data" in response && response.data.errors;
     if (isNotifyError) {

--- a/worker/src/queues/notify/workers/notifyHandler.ts
+++ b/worker/src/queues/notify/workers/notifyHandler.ts
@@ -20,7 +20,7 @@ type NotifyJob = {
 };
 
 /**
- * When a "submission" event is detected, this worker POSTs the data to `job.data.data.webhook_url`
+ * When a "notifications" event is detected, this worker POSTs the data to `job.data.data.webhook_url`
  * The source of this event is the runner, after a user has submitted a form.
  */
 export async function notifyHandler(job: Job<NotifyJob>) {

--- a/worker/src/types/notify.d.ts
+++ b/worker/src/types/notify.d.ts
@@ -1,0 +1,122 @@
+declare module "notifications-node-client" {
+  class NotifyClient {
+    constructor(apiKey: string);
+
+    setProxy: (config: ProxyConfig) => void;
+
+    sendEmail: <T extends { [key: string]: any }>(templateId: string, emailAddress: string, options: SendEmailOptions<T>) => Response<SendEmailResponse>;
+
+    getNotificationById: (notificationId: string) => Response<GetNotificationByIdResponse>;
+
+    getNotifications: (templateType?: string, status?: Status, reference?: string, olderThan?: string) => Response<GetNotificationByIdResponse>;
+
+    prepareUpload: (fileData: Buffer, isCsv: boolean) => PreparedUpload;
+  }
+
+  interface ProxyConfig {
+    host: string;
+    port: number;
+  }
+
+  interface SendEmailOptions<PersonalisationFields extends { [key: string]: any }> {
+    personalisation: PersonalisationFields;
+    reference: string;
+    emailReplyToId?: string;
+  }
+
+  interface SendEmailResponse {
+    content: {
+      body: string;
+      from_email: string;
+      subject: string;
+    };
+    id: string;
+    reference?: string;
+    template: Template;
+    uri: string;
+  }
+
+  type Status = "created" | "sending" | "delivered" | "permanent-failure" | "temporary-failure" | "technical-failure";
+
+  interface GetNotificationByIdEmailResponse {
+    body: string;
+    completed_at: string;
+    created_at: string;
+    created_by_name: string;
+    email_address: string;
+    id: string;
+    reference?: string;
+    sent_at: string;
+    status: Status;
+    subject: string;
+    template: Template;
+    type: "email";
+  }
+  interface GetNotificationByIdSMSResponse {
+    body: string;
+    completed_at: string;
+    created_at: string;
+    created_by_name: string;
+    email_address: string;
+    id: string;
+    phone_number: string;
+    reference: null;
+    sent_at: string;
+    status: Status;
+    subject: string;
+    template: Template;
+    type: "sms";
+  }
+
+  interface GetNotificationByIdLetterResponse {
+    body: string;
+    completed_at: string;
+    created_at: string;
+    created_by_name: string;
+    email_address: string;
+    id: string;
+    line_1: string;
+    line_2?: string;
+    line_3: string;
+    line_4?: string;
+    line_5?: string;
+    line_6?: string;
+    postage?: "first" | "second";
+    reference?: string;
+    scheduled_for: string;
+    sent_at?: string;
+    status: Status;
+    subject: string;
+    template: Template;
+    type: "letter";
+  }
+
+  type GetNotificationByIdResponse = GetNotificationByIdEmailResponse | GetNotificationByIdLetterResponse | GetNotificationByIdSMSResponse;
+
+  interface Template {
+    id: string;
+    uri: string;
+    version: number;
+  }
+
+  interface GetNotificationsResponse {
+    notifications: [GetNotificationByIdResponse];
+  }
+
+  export interface PreparedUpload {
+    file: string;
+    is_csv: boolean;
+  }
+
+  type Response<T> = Promise<{ status: number; data: T | ErrorResponse }>;
+
+  interface ErrorResponse {
+    status_code: number;
+    errors: RequestError[];
+  }
+
+  interface RequestError {
+    error: string;
+    message: string;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2725,6 +2725,7 @@ __metadata:
     nanoid: 3.3.4
     nodemon: ^3.0.1
     notifications-node-client: ^8.0.0
+    pg-boss: ^9.0.3
     pino: ^8.15.4
     pino-http: ^8.5.0
     prettier: ^3.0.3
@@ -2755,6 +2756,7 @@ __metadata:
     jest: ^29.7.0
     jest-mock-extended: ^3.0.5
     nodemon: ^3.0.1
+    notifications-node-client: ^8.0.0
     pg-boss: ^9.0.3
     pino: ^8.17.2
     prettier: ^3.0.3


### PR DESCRIPTION
Sending notify (user) emails to queue first for the worker to do the sending.

**api**
- remove reference to notify api keys and related errors
- tidy environment variable structure 
- exiting the app immediately (process.exit) if the environment variables are not configured - rather than letting the error be sent as a response.

**worker**
- handle notify messages 