### PR TITLE
refactor: remove need for EmailServiceProvider

### DIFF
--- a/api/src/middlewares/services/EmailService/NotifyService.ts
+++ b/api/src/middlewares/services/EmailService/NotifyService.ts
@@ -2,7 +2,7 @@ import config from "config";
 import pino, { Logger } from "pino";
 import { ApplicationError } from "../../../ApplicationError";
 import * as additionalContexts from "./additionalContexts.json";
-import { EmailServiceProvider, NotifyPersonalisation, NotifySendEmailArgs, NotifyEmailTemplate } from "./types";
+import { NotifyEmailTemplate, NotifyPersonalisation, NotifySendEmailArgs } from "./types";
 import * as templates from "./templates";
 import { FormField } from "../../../types/FormField";
 import { answersHashMap } from "../helpers";
@@ -16,7 +16,7 @@ const previousMarriageDocs = {
   "Surviving civil partner": "late partner's death certificate",
   Annulled: "decree of nullity",
 };
-export class NotifyService implements EmailServiceProvider {
+export class NotifyService {
   logger: Logger;
   templates: Record<NotifyEmailTemplate, string>;
   queue?: PgBoss;

--- a/api/src/middlewares/services/EmailService/SESService.ts
+++ b/api/src/middlewares/services/EmailService/SESService.ts
@@ -4,7 +4,7 @@ import { ApplicationError } from "../../../ApplicationError";
 import { FormField } from "../../../types/FormField";
 import * as templates from "./templates";
 import additionalContexts from "./additionalContexts.json";
-import { EmailServiceProvider, isSESEmailTemplate, SESEmailTemplate } from "./types";
+import { SESEmailTemplate } from "./types";
 import config from "config";
 import { getFileFields, answersHashMap } from "../helpers";
 import PgBoss from "pg-boss";
@@ -27,7 +27,7 @@ type PaymentViewModel = {
   };
 };
 
-export class SESService implements EmailServiceProvider {
+export class SESService {
   logger: Logger;
   templates: Record<SESEmailTemplate, HandlebarsTemplateDelegate>;
   queue?: PgBoss;
@@ -68,15 +68,12 @@ export class SESService implements EmailServiceProvider {
 
   async send(
     fields: FormField[],
-    template: string,
+    template: SESEmailTemplate,
     metadata: {
       reference: string;
       payment?: PayMetadata;
     }
   ) {
-    if (!isSESEmailTemplate(template)) {
-      throw new ApplicationError("SES", "TEMPLATE_NOT_FOUND", 400);
-    }
     const { reference, payment } = metadata;
 
     const emailArgs = await this.buildSendEmailArgs({ fields, payment }, template, reference);

--- a/api/src/middlewares/services/EmailService/types.ts
+++ b/api/src/middlewares/services/EmailService/types.ts
@@ -1,5 +1,4 @@
 import { SendEmailOptions } from "notifications-node-client";
-import { FormField } from "../../../types/FormField";
 import { notify } from "./templates";
 
 export interface NotifySendEmailArgs {
@@ -9,16 +8,6 @@ export interface NotifySendEmailArgs {
 }
 
 export type SESEmailTemplate = "affirmation" | "cni";
-
-export function isSESEmailTemplate(template: string): template is SESEmailTemplate {
-  return template === "affirmation" || template === "cni";
-}
-
 export type NotifyEmailTemplate = "userConfirmation" | "postNotification";
-export type EmailTemplate = SESEmailTemplate & NotifyEmailTemplate;
 
 export type NotifyPersonalisation = typeof notify.userConfirmation | typeof notify.postNotification;
-
-export interface EmailServiceProvider {
-  send: (fields: FormField[], template: EmailTemplate, reference: string) => Promise<any>;
-}


### PR DESCRIPTION
SES (and Notify) services are too specialised for them to conform to the same interface