### PR TITLE
fix: affirmation template mapping

### DIFF
--- a/api/src/middlewares/services/StaffService/__tests__/__snapshots__/remappers.test.ts.snap
+++ b/api/src/middlewares/services/StaffService/__tests__/__snapshots__/remappers.test.ts.snap
@@ -47,6 +47,13 @@ exports[`affirmation is successfully remapped 1`] = `
       "title": "Country of birth",
       "type": "list",
     },
+    "dateOfBirth": {
+      "answer": "2000-11-11",
+      "category": "applicantDetails",
+      "key": "dateOfBirth",
+      "title": "Date of birth",
+      "type": "date",
+    },
     "nameChangedByDeedPoll": {
       "answer": "By deed poll",
       "category": "nameChange",
@@ -63,20 +70,6 @@ exports[`affirmation is successfully remapped 1`] = `
     },
   },
   "applicantDetails": {
-    "dateOfBirth": {
-      "answer": "2000-11-11",
-      "category": "applicantDetails",
-      "key": "dateOfBirth",
-      "title": "Date of birth",
-      "type": "date",
-    },
-    "emailAddress": {
-      "answer": "pye@cautionyourblast.com",
-      "category": "contact",
-      "key": "emailAddress",
-      "title": "Email address",
-      "type": "text",
-    },
     "firstName": {
       "answer": "Test",
       "category": "applicantDetails",
@@ -89,13 +82,6 @@ exports[`affirmation is successfully remapped 1`] = `
       "category": "applicantDetails",
       "key": "middleName",
       "title": "Middle name",
-      "type": "text",
-    },
-    "phoneNumber": {
-      "answer": "+440000000",
-      "category": "contact",
-      "key": "phoneNumber",
-      "title": "Phone number",
       "type": "text",
     },
     "sex": {
@@ -126,6 +112,22 @@ exports[`affirmation is successfully remapped 1`] = `
       "category": "applicantDetails",
       "key": "passportNumber",
       "title": "Passport number",
+      "type": "text",
+    },
+  },
+  "contactDetails": {
+    "emailAddress": {
+      "answer": "pye@cautionyourblast.com",
+      "category": "contact",
+      "key": "emailAddress",
+      "title": "Email address",
+      "type": "text",
+    },
+    "phoneNumber": {
+      "answer": "+440000000",
+      "category": "contact",
+      "key": "phoneNumber",
+      "title": "Phone number",
       "type": "text",
     },
   },

--- a/api/src/middlewares/services/StaffService/__tests__/__snapshots__/reorderers.test.ts.snap
+++ b/api/src/middlewares/services/StaffService/__tests__/__snapshots__/reorderers.test.ts.snap
@@ -129,6 +129,7 @@ exports[`affirmation is successfully remapped 1`] = `
       "type": "text",
     },
   },
+  "Contact details": undefined,
   "Feedback consent": {
     "feedbackConsent": {
       "answer": true,
@@ -272,5 +273,6 @@ exports[`affirmation is successfully remapped 1`] = `
       "type": "list",
     },
   },
+  "Postal address": undefined,
 }
 `;

--- a/api/src/middlewares/services/StaffService/mappings/affirmation.ts
+++ b/api/src/middlewares/services/StaffService/mappings/affirmation.ts
@@ -12,6 +12,7 @@ export const order = {
   partnerNationality: "Partner's nationality",
   partnerMaritalStatus: "Partner's marital and civil status",
   marriageDetails: "Marriage",
+  postalAddress: "Postal address",
   feedbackConsent: "Feedback consent",
 };
 
@@ -20,7 +21,6 @@ export const remap = {
   post: "information.post",
   jurats: "information.jurats",
   certifyPassport: "information.certifyPassport",
-  feedbackConsent: "feedbackConsent.feedbackConsent",
   oathType: "information.oathType",
 
   phoneNumber: "contactDetails.phoneNumber",
@@ -82,4 +82,12 @@ export const remap = {
 
   dateOfMarriage: "marriageDetails.dateOfMarriage",
   placeOfMarriage: "marriageDetails.placeOfMarriage",
+
+  deliveryAddressLine1: "postalAddress.addressLine1",
+  deliveryAddressLine2: "postalAddress.addressLine2",
+  deliveryCity: "postalAddress.city",
+  deliveryPostcode: "postalAddress.postcode",
+  deliveryCountry: "postalAddress.country",
+
+  feedbackConsent: "feedbackConsent.feedbackConsent",
 };

--- a/api/src/middlewares/services/StaffService/mappings/affirmation.ts
+++ b/api/src/middlewares/services/StaffService/mappings/affirmation.ts
@@ -1,11 +1,12 @@
 export const order = {
+  contactDetails: "Contact details",
   applicantDetails: "Applicant's details",
-  applicantAddress: "Applicant's address",
   applicantBirth: "Applicant's birth details",
-  applicantPassport: "Applicant's passport",
-  parentDetails: "Parents' details",
-  maritalStatus: "Marital and civil status",
+  applicantAddress: "Applicant's address",
   occupation: "Occupation",
+  parentDetails: "Parents' details",
+  applicantPassport: "Applicant's passport",
+  maritalStatus: "Marital and civil status",
   partnerName: "Partner's name",
   partnerAddress: "Partner's address",
   partnerNationality: "Partner's nationality",
@@ -22,19 +23,15 @@ export const remap = {
   feedbackConsent: "feedbackConsent.feedbackConsent",
   oathType: "information.oathType",
 
+  phoneNumber: "contactDetails.phoneNumber",
+  emailAddress: "contactDetails.emailAddress",
+
   firstName: "applicantDetails.firstName",
   middleName: "applicantDetails.middleName",
   surname: "applicantDetails.surname",
-  dateOfBirth: "applicantDetails.dateOfBirth",
   sex: "applicantDetails.sex",
-  emailAddress: "applicantDetails.emailAddress",
-  phoneNumber: "applicantDetails.phoneNumber",
 
-  addressLine1: "applicantAddress.addressLine1",
-  addressLine2: "applicantAddress.addressLine2",
-  city: "applicantAddress.city",
-  postcode: "applicantAddress.postcode",
-  countryAddress: "applicantAddress.country",
+  dateOfBirth: "applicantBirth.dateOfBirth",
   placeOfBirth: "applicantBirth.placeOfBirth",
   countryOfBirth: "applicantBirth.countryOfBirth",
   nameChangedByDeedPoll: "applicantBirth.nameChangedByDeedPoll",
@@ -42,12 +39,20 @@ export const remap = {
   nameChangedByMarriage: "applicantBirth.nameChangedByMarriage",
   previousNameByMarriage: "applicantBirth.previousNameByMarriage",
 
-  passportDateOfIssue: "applicantPassport.dateOfIssue",
-  passportNumber: "applicantPassport.number",
+  addressLine1: "applicantAddress.addressLine1",
+  addressLine2: "applicantAddress.addressLine2",
+  city: "applicantAddress.city",
+  postcode: "applicantAddress.postcode",
+  countryAddress: "applicantAddress.country",
+
+  occupation: "occupation.occupation",
 
   fatherFullName: "parentDetails.fatherFullName",
   motherFullName: "parentDetails.motherFullName",
   motherMaidenName: "parentDetails.motherMaidenName",
+
+  passportNumber: "applicantPassport.number",
+  passportDateOfIssue: "applicantPassport.dateOfIssue",
 
   maritalStatus: "maritalStatus.status",
   dateOfDecreeAbsolute: "maritalStatus.dateOfDecreeAbsolute",
@@ -60,8 +65,6 @@ export const remap = {
   placeOfDissolution: "maritalStatus.placeOfDissolution",
   dateOfDecreeOfNullity: "maritalStatus.dateOfDecreeOfNullity",
   placeOfDecreeOfNullity: "maritalStatus.placeOfDecreeOfNullity",
-
-  occupation: "occupation.occupation",
 
   partnerFirstName: "partnerName.partnerFirstName",
   partnerMiddleName: "partnerName.partnerMiddleName",

--- a/api/src/middlewares/services/StaffService/templates/submission.ts
+++ b/api/src/middlewares/services/StaffService/templates/submission.ts
@@ -45,12 +45,14 @@ const template = `
 
 
     {{#each questions}}
-        <h4>{{@key}}</h4>
-        <ul>
-            {{#each this}}
-            <li>{{this.title}}: {{this.answer}}</li>
-            {{/each}}
-        </ul>
+        {{#if this}}
+            <h4>{{@key}}</h4>
+            <ul>
+                {{#each this}}
+                <li>{{this.title}}: {{this.answer}}</li>
+                {{/each}}
+            </ul>
+        {{/if}}
     {{/each}}
 
 


### PR DESCRIPTION
### change 1
The remapper and reorderer for the affirmation service application email were originally arranged to assist post staff for inputting information into Casebook.

It was suggested that it might be more effective for posts if the information was displayed in the same format as the information appears in the affirmation document template. Sections and fields have been moved around accordingly.

### change 2
The CNI in-person service also uses the affirmation template, however the CNI in-person service also has additional fields for delivery details if the user would like their documents posted to them. These fields have now been added into the affirmation template to cope for this.

### change 3
As we have added the new section for delivery details for CNI in-person applications, we wanted to make sure this section didn't appear for affirmation applications. To solve this, an if statement has been added round the part of the template rendering the sections, making sure that at least one value exists in that section before rendering the section title.