### PR TITLE
fix: change docs list builder to pull through correct value for religious book doc

### DIFF
--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -106,7 +106,7 @@ test("buildDocsList will add optional documents when the relevant fields are fil
     ...answers,
     marriedBefore: true,
     maritalStatus: "Divorced",
-    oathType: "affidavit",
+    oathType: "Religious",
   };
   expect(buildUserConfirmationDocsList(fieldsMap, "affirmation")).toBe(
     `* your UK passport\n* your birth certificate\n* proof of address – you must use your residence permit if the country you live in issues these\n* your partner’s passport or national identity card\n* decree absolute\n* religious book of your faith to swear upon`

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -56,7 +56,7 @@ export function buildUserConfirmationDocsList(fields: AnswersHashMap, type?: For
   if (fields.maritalStatus && fields.maritalStatus !== "Never married") {
     docsList.push(`${previousMarriageDocs[fields.maritalStatus as string]}`);
   }
-  if (fields.oathType === "affidavit") {
+  if (fields.oathType === "Religious") {
     docsList.push("religious book of your faith to swear upon");
   }
   const country = fields.country as string;


### PR DESCRIPTION
The form has been updated in the past, causing the value from the oath type field to have changed from "affirmation" or "affidavit" to "Non-religious" and "Religious". As a result, the docs list builder function needed to be updated to reflect this change.