### PR TITLE
fix: Update docs list for in-person cni

### DIFF
--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -21,7 +21,7 @@ const formFields = flattenQuestions(testData.questions);
 const answers = answersHashMap(formFields);
 
 test("buildSendEmailArgs should return the correct personalisation for an in-person email", () => {
-  const personalisation = PersonalisationBuilder.userConfirmation(answers, { reference: "1234" });
+  const personalisation = PersonalisationBuilder.userConfirmation(answers, { type: "affirmation", reference: "1234" });
   expect(personalisation).toEqual({
     firstName: "foo",
     docsList:
@@ -121,6 +121,6 @@ test("buildDocsList will add cni proof of stay doc if the form type is cni", () 
     oathType: "affirmation",
   };
   expect(buildUserConfirmationDocsList(fieldsMap, "cni")).toBe(
-    `* your UK passport\n* your birth certificate\n* proof of address – you must use your residence permit if the country you live in issues these\n* proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address\n* your partner’s passport or national identity card`
+    `* your UK passport\n* proof of address – you must use your residence permit if the country you live in issues these\n* proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address\n* your partner’s passport or national identity card`
   );
 });

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -55,7 +55,7 @@ export function buildUserConfirmationDocsList(fields: AnswersHashMap, type?: For
 
   // for cnis, the user needs to provide proof they have stayed in the country for 3 days. For contextual reasons, this should appear below the proof of address doc
   if (type === "cni") {
-    docsList.splice(3, 0, "proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address");
+    docsList.splice(2, 0, "proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address");
   }
   if (fields.maritalStatus && fields.maritalStatus !== "Never married") {
     docsList.push(`${previousMarriageDocs[fields.maritalStatus as string]}`);

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -44,10 +44,14 @@ export function buildUserConfirmationDocsList(fields: AnswersHashMap, type?: For
 
   const docsList = [
     "your UK passport",
-    "your birth certificate",
     "proof of address – you must use your residence permit if the country you live in issues these",
     "your partner’s passport or national identity card",
   ];
+
+  // for affirmations, users need to provide their birth certificate. For contextual reasons, this should appear next to the user's passport
+  if (type === "affirmation") {
+    docsList.splice(1, 0, "your birth certificate");
+  }
 
   // for cnis, the user needs to provide proof they have stayed in the country for 3 days. For contextual reasons, this should appear below the proof of address doc
   if (type === "cni") {


### PR DESCRIPTION
Previously all forms that used the docsList variable had the birth certificate added. Birth certificate should only show for affirmation applications though, so the buildDocsList function has been updated to reflect this.