### PR TITLE
feat: add error for if no post email could be found

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -160,18 +160,19 @@ The following errors are logged by the API. They may be inserted into the databa
 Below is a summary of the errors that may be logged by the API. Some errors may have steps to remediate.
 
 
-| Error type | Error code           | Comment                                                                                        |
-|------------|----------------------|------------------------------------------------------------------------------------------------|
-| WEBHOOK    | VALIDATION           | POST from forms-worker (or forms runner) failed validation.                                    |
-| SES        | PROCESS_VALIDATION   | POST to /forms/emails/staff failed validation                                                  |
-| SES        | MISSING_ANSWER       | Expected answer is missing. Check the queue database first, then the notarial database         |
-| SES        | UNKNOWN              | The error has been identified as relating to SES, but logs must be checked for further details |
-| NOTIFY     | PROCESS_VALIDATION   | POST to /forms/emails/user failed validation                                                   |
-| NOTIFY     | UNKNOWN              | The error has been identified as relating to NOTIFY (or UserService)                           |
-| QUEUE      | SES_PROCESS_ERROR    | Inserting into queue failed                                                                    |
-| QUEUE      | NOTIFY_PROCESS_ERROR | Inserting into queue failed                                                                    |
-| GENERIC    | UNKNOWN              |                                                                                                |
-| GENERIC    | RATE_LIMIT           | Rate limit exceeded. If required, this can be changed by adjusting `RATE_LIMIT` env var        |
+| Error type | Error code                  | Comment                                                                                                                                     |
+|------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| WEBHOOK    | VALIDATION                  | POST from forms-worker (or forms runner) failed validation.                                                                                 |
+| SES        | PROCESS_VALIDATION          | POST to /forms/emails/staff failed validation                                                                                               |
+| SES        | MISSING_ANSWER              | Expected answer is missing. Check the queue database first, then the notarial database                                                      |
+| SES        | UNKNOWN                     | The error has been identified as relating to SES, but logs must be checked for further details                                              |
+| NOTIFY     | PROCESS_VALIDATION          | POST to /forms/emails/user failed validation                                                                                                |
+| NOTIFY     | UNKNOWN                     | The error has been identified as relating to NOTIFY (or UserService)                                                                        |
+| QUEUE      | SES_PROCESS_ERROR           | Inserting into queue failed                                                                                                                 |
+| QUEUE      | NOTIFY_PROCESS_ERROR        | Inserting into queue failed                                                                                                                 |
+| GENERIC    | UNKNOWN                     |                                                                                                                                             |
+| GENERIC    | RATE_LIMIT                  | Rate limit exceeded. If required, this can be changed by adjusting `RATE_LIMIT` env var                                                     |
+| GENERIC    | UNKNOWN_SERVICE_APPLICATION | An email address could not be found for the specified post. This implies that a user should not be able to apply for a service at this post |
 
 
 For the API, generally you may fix the issues in a few ways

--- a/api/src/errors.ts
+++ b/api/src/errors.ts
@@ -27,7 +27,7 @@ type SESErrorCode = "MISSING_ANSWER" | "PROCESS_VALIDATION" | "UNKNOWN";
 type NotifyErrorCode = "PROCESS_VALIDATION" | "UNKNOWN";
 type QueueErrorCode = "SES_PROCESS_ERROR" | "NOTIFY_PROCESS_ERROR" | "NOTIFY_SEND_ERROR" | "SES_SEND_ERROR";
 
-type GenericErrorCode = "UNKNOWN" | "RATE_LIMIT_EXCEEDED";
+type GenericErrorCode = "UNKNOWN" | "RATE_LIMIT_EXCEEDED" | "UNRECOGNISED_SERVICE_APPLICATION";
 
 /**
  * Union of all the different ErrorCode.
@@ -59,6 +59,7 @@ const NOTIFY: ErrorRecord<NotifyErrorCode> = {
 const GENERIC: ErrorRecord<GenericErrorCode> = {
   UNKNOWN: "Unknown error",
   RATE_LIMIT_EXCEEDED: "Rate limit exceeded",
+  UNRECOGNISED_SERVICE_APPLICATION: "Current service could not be processed, as it was not recognised",
 };
 
 const QUEUE: ErrorRecord<QueueErrorCode> = {

--- a/api/src/errors.ts
+++ b/api/src/errors.ts
@@ -27,7 +27,7 @@ type SESErrorCode = "MISSING_ANSWER" | "PROCESS_VALIDATION" | "UNKNOWN";
 type NotifyErrorCode = "PROCESS_VALIDATION" | "UNKNOWN";
 type QueueErrorCode = "SES_PROCESS_ERROR" | "NOTIFY_PROCESS_ERROR" | "NOTIFY_SEND_ERROR" | "SES_SEND_ERROR";
 
-type GenericErrorCode = "UNKNOWN" | "RATE_LIMIT_EXCEEDED" | "UNRECOGNISED_SERVICE_APPLICATION";
+type GenericErrorCode = "UNKNOWN" | "RATE_LIMIT_EXCEEDED";
 
 /**
  * Union of all the different ErrorCode.
@@ -59,7 +59,6 @@ const NOTIFY: ErrorRecord<NotifyErrorCode> = {
 const GENERIC: ErrorRecord<GenericErrorCode> = {
   UNKNOWN: "Unknown error",
   RATE_LIMIT_EXCEEDED: "Rate limit exceeded",
-  UNRECOGNISED_SERVICE_APPLICATION: "Current service could not be processed, as it was not recognised",
 };
 
 const QUEUE: ErrorRecord<QueueErrorCode> = {

--- a/api/src/middlewares/services/StaffService/StaffService.ts
+++ b/api/src/middlewares/services/StaffService/StaffService.ts
@@ -171,7 +171,7 @@ export class StaffService {
     if (!emailAddress) {
       this.logger.error(
         { code: "UNRECOGNISED_SERVICE_APPLICATION" },
-        `No email address for the specified post – ${country} - ${post} – could be found. This is for application with the reference ${reference}.`
+        `No email address found for the specified post – ${country} - ${post} – reference ${reference}.`
       );
       return;
     }

--- a/api/src/middlewares/services/StaffService/StaffService.ts
+++ b/api/src/middlewares/services/StaffService/StaffService.ts
@@ -16,6 +16,7 @@ import { getPost } from "../utils/getPost";
 import { getPostEmailAddress } from "../utils/getPostEmailAddress";
 import { PersonalisationBuilder } from "../UserService/personalisation/PersonalisationBuilder";
 import { SESEmailTemplate } from "../utils/types";
+import { ApplicationError } from "../../../ApplicationError";
 
 type PaymentViewModel = {
   id: string;
@@ -169,7 +170,14 @@ export class StaffService {
     const emailAddress = getPostEmailAddress(country, post);
     const personalisation = PersonalisationBuilder.postNotification(answers, type);
     if (!emailAddress) {
-      this.logger.warn(`No email address found for country ${country} - post ${post}. Post notification will not be sent`);
+      this.logger.error(
+        new ApplicationError(
+          "GENERIC",
+          "UNRECOGNISED_SERVICE_APPLICATION",
+          400,
+          "The currently selected post does not have an associated email address. This indicates the current country should not be using this service."
+        )
+      );
       return;
     }
 

--- a/api/src/middlewares/services/StaffService/StaffService.ts
+++ b/api/src/middlewares/services/StaffService/StaffService.ts
@@ -171,12 +171,8 @@ export class StaffService {
     const personalisation = PersonalisationBuilder.postNotification(answers, type);
     if (!emailAddress) {
       this.logger.error(
-        new ApplicationError(
-          "GENERIC",
-          "UNRECOGNISED_SERVICE_APPLICATION",
-          400,
-          "The currently selected post does not have an associated email address. This indicates the current country should not be using this service."
-        )
+        { code: "UNRECOGNISED_SERVICE_APPLICATION" },
+        `No email address for the specified post – ${country} - ${post} – could be found. This is for application with the reference ${reference}.`
       );
       return;
     }

--- a/api/src/middlewares/services/StaffService/StaffService.ts
+++ b/api/src/middlewares/services/StaffService/StaffService.ts
@@ -16,7 +16,6 @@ import { getPost } from "../utils/getPost";
 import { getPostEmailAddress } from "../utils/getPostEmailAddress";
 import { PersonalisationBuilder } from "../UserService/personalisation/PersonalisationBuilder";
 import { SESEmailTemplate } from "../utils/types";
-import { ApplicationError } from "../../../ApplicationError";
 
 type PaymentViewModel = {
   id: string;


### PR DESCRIPTION
For every country that has been digitised, there should be an associated email address for every post in that country. If no email address is mapped for that post, then the post will never receive the alert saying there's a new application.

Furthermore, if no post email has been set for that specific post, it indicates that a user was able to submit an application for a country that should not be receiving applications. For example, China has a separate service for applying for a marriage affirmation, and so the notarial api should not be able to receive applications for China.

To solve this, a change has been made so that if an email cannot be found for the selected post, the submission email is still sent so that we have a record of the user's details to contact them, however an error is raised with the code `UNRECOGNISED_SERVICE_APPLICATION`