### PR TITLE
fix: change dynamic content upload to recognise hybrid as a truthy value

### DIFF
--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -58,7 +58,7 @@ test("getUserPostalConfirmationAdditionalContext returns additionalContext corre
     additionalDocs: "",
     bookingLink: "https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=33&service=10",
     civilPartnership: false,
-    cniDelivery: false,
+    cniDelivery: true,
     duration: "6 months",
     localRequirements: "",
     post: "the British Embassy Rome",

--- a/api/src/middlewares/services/utils/additionalContexts.json
+++ b/api/src/middlewares/services/utils/additionalContexts.json
@@ -133,7 +133,7 @@
       "additionalDocs": [
         "either the proof of address or your partner's ID must prove that you or your partner live in Bulgaria or your partner is a Bulgarian national"
       ],
-      "cniDelivery": false,
+      "cniDelivery": true,
       "localRequirements": ""
     },
     "Burkina Faso": {
@@ -221,7 +221,7 @@
       "duration": "3 months",
       "postal": true,
       "additionalDocs": "",
-      "cniDelivery": false,
+      "cniDelivery": true,
       "localRequirements": "\nIn addition to a CNI you will also need a Certificate of Custom/Law issued by the British Embassy Zagreb. You can apply for this when you apply to exchange your UK CNI.  \nYou will need to give the registrar a [legalised (apostilled)](https://www.gov.uk/get-document-legalised) and [translated](https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find/translators-interpreters) birth certificate. If you are divorced or widowed you will also need to have your decree absolute or partner's death certificate legalised (apostilled) and translated."
     },
     "Cuba": {
@@ -1019,7 +1019,7 @@
       "localRequirements": ""
     },
     "Ireland": { "civilPartnership": false, "duration": "", "postal": false, "additionalDocs": "", "cniDelivery": false, "localRequirements": "" },
-    "Italy": { "civilPartnership": false, "duration": "6 months", "postal": true, "additionalDocs": "", "cniDelivery": false, "localRequirements": "" },
+    "Italy": { "civilPartnership": false, "duration": "6 months", "postal": true, "additionalDocs": "", "cniDelivery": true, "localRequirements": "" },
     "Jamaica": { "civilPartnership": false, "duration": "", "postal": false, "additionalDocs": "", "cniDelivery": false, "localRequirements": "" },
     "Japan": { "civilPartnership": false, "duration": "3 months", "postal": false, "additionalDocs": "", "cniDelivery": false, "localRequirements": "" },
     "Kenya": { "civilPartnership": false, "duration": "", "postal": false, "additionalDocs": "", "cniDelivery": false, "localRequirements": "" },

--- a/dynamic-content/helpers.ts
+++ b/dynamic-content/helpers.ts
@@ -54,11 +54,22 @@ function parseRowContent(row: Row) {
 }
 
 function parseContent(acc: Record<string, string>, [key, value]) {
-  if (key === "type" && value) value = value.toLowerCase();
-  if (key === "additionalDocs" && value) value = bulletsToArray(value);
-  if (value && value.includes("<br>")) value = value.replaceAll("<br>", "\n");
-  if (key === "civilPartnership") value = !!value;
-  if (key === "postal" || key === "cniDelivery") value = !!value && value?.toLowerCase() !== "false";
+  const hasValue = !!value;
+  if (key === "type" && hasValue) {
+    value = value.toLowerCase();
+  }
+  if (key === "additionalDocs" && hasValue) {
+    value = bulletsToArray(value);
+  }
+  if (hasValue && value.includes("<br>")) {
+    value = value.replaceAll("<br>", "\n");
+  }
+  if (key === "civilPartnership") {
+    value = hasValue;
+  }
+  if (key === "postal" || key === "cniDelivery") {
+    value = hasValue && value?.toLowerCase() !== "false";
+  }
   acc[key] = value;
   return acc;
 }

--- a/dynamic-content/helpers.ts
+++ b/dynamic-content/helpers.ts
@@ -58,8 +58,7 @@ function parseContent(acc: Record<string, string>, [key, value]) {
   if (key === "additionalDocs" && value) value = bulletsToArray(value);
   if (value && value.includes("<br>")) value = value.replaceAll("<br>", "\n");
   if (key === "civilPartnership") value = !!value;
-  if (key === "postal") value = !!value && value?.toLowerCase() !== "false";
-  if (key === "cniDelivery") value = !!value && value?.toLowerCase() === "true";
+  if (key === "postal" || key === "cniDelivery") value = !!value && value?.toLowerCase() !== "false";
   acc[key] = value;
   return acc;
 }


### PR DESCRIPTION
- for the exchange journey, whether the country allows a postal application or in-person application depends on whether the country allows CNI delivery. A country that has the value `true` or `hybrid` should show the postal content