### PR TITLE
feat: Add partner's previous marriage document for Italy postal journey

### DIFF
--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -49,6 +49,7 @@ test("buildSendEmailArgs should return the correct personalisation for a postal 
     reference: "1234",
     postAddress: "",
     previousMarriage: false,
+    italyPartnerPreviousMarriage: false,
     notPaid: true,
   });
 });

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userPostalConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userPostalConfirmation.ts
@@ -20,7 +20,8 @@ export function buildUserPostalConfirmationPersonalisation(answers: AnswersHashM
   const previousMarriage = answers.maritalStatus && answers.maritalStatus !== "Never married";
 
   // Italy is the only country that requires the partner's proof of end of marriage doc
-  const italyPartnerPreviousMarriage = country === "Italy" && answers.partnerMaritalStatus && answers.partnerMaritalStatus !== "Never married";
+  const partnerHasPreviousMarriage = answers.partnerMaritalStatus && answers.partnerMaritalStatus !== "Never married";
+  const italyPartnerPreviousMarriage = country === "Italy" && partnerHasPreviousMarriage;
 
   const additionalContext = getUserPostalConfirmationAdditionalContext(country, post);
 

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userPostalConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userPostalConfirmation.ts
@@ -19,6 +19,9 @@ export function buildUserPostalConfirmationPersonalisation(answers: AnswersHashM
   const post = answers["post"] as string;
   const previousMarriage = answers.maritalStatus && answers.maritalStatus !== "Never married";
 
+  // Italy is the only country that requires the partner's proof of end of marriage doc
+  const italyPartnerPreviousMarriage = country === "Italy" && answers.partnerMaritalStatus && answers.partnerMaritalStatus !== "Never married";
+
   const additionalContext = getUserPostalConfirmationAdditionalContext(country, post);
 
   return {
@@ -29,6 +32,7 @@ export function buildUserPostalConfirmationPersonalisation(answers: AnswersHashM
     localRequirements: additionalContext.localRequirements,
     civilPartnership: additionalContext.civilPartnership,
     previousMarriage,
+    italyPartnerPreviousMarriage,
     reference: metadata.reference,
     postAddress: additionalContext.postAddress,
     notPaid: !isSuccessfulPayment,


### PR DESCRIPTION
Italy requires the user to send the proof a partner's previous marriage has ended if they've been previously married. A new variable is being passed through to Notify to check for this.