### PR TITLE
feat: only add proof of address doc to docs list for cni if the user does not live in the country

### DIFF
--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -115,7 +115,7 @@ test("buildDocsList will add optional documents when the relevant fields are fil
   );
 });
 
-test("buildDocsList will add cni proof of stay doc if the form type is cni", () => {
+test("buildDocsList will add cni proof of stay doc if the form type is cni and the user does not live in the country", () => {
   const answers = answersHashMap(formFields);
   const fieldsMap = {
     ...answers,
@@ -123,6 +123,19 @@ test("buildDocsList will add cni proof of stay doc if the form type is cni", () 
     oathType: "affirmation",
   };
   expect(buildUserConfirmationDocsList(fieldsMap, "cni")).toBe(
-    `* your UK passport\n* proof of address – you must use your residence permit if the country you live in issues these\n* proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address\n* your partner’s passport or national identity card`
+    `* your UK passport\n* proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address\n* your partner’s passport or national identity card`
+  );
+});
+
+test("buildDocsList will add proof of address doc if the form type is cni and the user lives in the country", () => {
+  const answers = answersHashMap(formFields);
+  const fieldsMap = {
+    ...answers,
+    marriedBefore: false,
+    oathType: "affirmation",
+    livesInCountry: true,
+  };
+  expect(buildUserConfirmationDocsList(fieldsMap, "cni")).toBe(
+    `* your UK passport\n* proof of address – you must use your residence permit if the country you live in issues these\n* your partner’s passport or national identity card`
   );
 });

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -44,20 +44,21 @@ export function buildUserConfirmationDocsList(fields: AnswersHashMap, type?: For
 
   const docsList = ["your UK passport", "your partner’s passport or national identity card"];
 
+  // for cni applications, proof of address is only required if the user lives in the country. For affirmation applications, proof of address is always required
+  if (type === "affirmation" || (type === "cni" && fields.livesInCountry)) {
+    docsList.splice(1, 0, "proof of address – you must use your residence permit if the country you live in issues these");
+  }
+
+  // for cnis, the user needs to provide proof they have stayed in the country for 3 days. For contextual reasons, this should appear below the proof of address doc
+  if (type === "cni" && !fields.livesInCountry) {
+    docsList.splice(1, 0, "proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address");
+  }
+
   // for affirmations, users need to provide their birth certificate. For contextual reasons, this should appear next to the user's passport
   if (type === "affirmation") {
     docsList.splice(1, 0, "your birth certificate");
   }
 
-  // for cni applications, proof of address is only required if the user lives in the country. For affirmation applications, proof of address is always required
-  if (type === "affirmation" || (type === "cni" && fields.livesInCountry)) {
-    docsList.splice(2, 0, "proof of address – you must use your residence permit if the country you live in issues these");
-  }
-
-  // for cnis, the user needs to provide proof they have stayed in the country for 3 days. For contextual reasons, this should appear below the proof of address doc
-  if (type === "cni" && !fields.livesInCountry) {
-    docsList.splice(2, 0, "proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address");
-  }
   if (fields.maritalStatus && fields.maritalStatus !== "Never married") {
     docsList.push(`${previousMarriageDocs[fields.maritalStatus as string]}`);
   }

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -42,19 +42,20 @@ export function buildUserConfirmationDocsList(fields: AnswersHashMap, type?: For
     throw new ApplicationError("WEBHOOK", "VALIDATION", 500, "Fields are empty");
   }
 
-  const docsList = [
-    "your UK passport",
-    "proof of address – you must use your residence permit if the country you live in issues these",
-    "your partner’s passport or national identity card",
-  ];
+  const docsList = ["your UK passport", "your partner’s passport or national identity card"];
 
   // for affirmations, users need to provide their birth certificate. For contextual reasons, this should appear next to the user's passport
   if (type === "affirmation") {
     docsList.splice(1, 0, "your birth certificate");
   }
 
+  // for cni applications, proof of address is only required if the user lives in the country. For affirmation applications, proof of address is always required
+  if (type === "affirmation" || (type === "cni" && fields.livesInCountry)) {
+    docsList.splice(2, 0, "proof of address – you must use your residence permit if the country you live in issues these");
+  }
+
   // for cnis, the user needs to provide proof they have stayed in the country for 3 days. For contextual reasons, this should appear below the proof of address doc
-  if (type === "cni") {
+  if (type === "cni" && !fields.livesInCountry) {
     docsList.splice(2, 0, "proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address");
   }
   if (fields.maritalStatus && fields.maritalStatus !== "Never married") {


### PR DESCRIPTION
For CNIs, the user either needs to bring proof they've been in the country for 3 days if they aren't residents, or proof of address if the user is a resident.

Previously proof of address was being requested regardless, so now this has been changed to reflect the above logic.