### PR TITLE
fix: ensure code throws when url is invalid

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -284,12 +284,13 @@ There is an issue adding data to the database. Investigate RDS.
 
 The following are thrown errors, and may be inserted in the database. They have been parsed as `ApplicationError`s to simplify debugging.
 
-| Error type | Error code           | Comment                                                                                        |
-|------------|----------------------|------------------------------------------------------------------------------------------------|
-| FILE       | ORIGIN_NOT_ALLOWED   | Attempted to fetch a file that is not the document upload API                                  |
-| FILE       | NOT_FOUND            | document upload API returned a 404                                                             |
-| FILE       | UNKNOWN              | An error was identified as relating to file code, but logs must be checked for further details |
-| CONSUMER   | START_FAILED         | Connection to database/queue could not be established                                          |
+| Error type | Error code         | Comment                                                                                        |
+|------------|--------------------|------------------------------------------------------------------------------------------------|
+| FILE       | ORIGIN_NOT_ALLOWED | Attempted to fetch a file that is not the document upload API                                  |
+| FILE       | NOT_FOUND          | document upload API returned a 404                                                             |
+| FILE       | URL_INVALID        | The URL is invalid                                                                             |
+| FILE       | UNKNOWN            | An error was identified as relating to file code, but logs must be checked for further details |
+| CONSUMER   | START_FAILED       | Connection to database/queue could not be established                                          |
 
 The following are logged errors and related to sending requests. These errors are caught, logged, and rethrown with 
 minimal parsing to preserve as much data as possible. 

--- a/worker/src/queues/ses/helpers/FileService.ts
+++ b/worker/src/queues/ses/helpers/FileService.ts
@@ -18,8 +18,8 @@ export default class FileService {
       url = new URL(urlToValidate);
     } catch (e) {
       this.logger.error(`url ${urlToValidate} is not a valid URL`);
+      throw new ApplicationError("FILE", "URL_INVALID", `url: ${urlToValidate} was invalid`);
     }
-    // @ts-ignore
     return this.allowedOrigins.includes(url.origin);
   }
 

--- a/worker/src/queues/ses/helpers/__tests__/attachFilesToMessage.test.ts
+++ b/worker/src/queues/ses/helpers/__tests__/attachFilesToMessage.test.ts
@@ -1,0 +1,19 @@
+import { attachFilesToMessage } from "../SESEmail";
+import { ApplicationError } from "../../../../utils/ApplicationError";
+
+test("attachFilesToMessages throws an error when the answer is an invalid URL", async () => {
+  function callAttachFilesToMessage() {
+    return attachFilesToMessage(
+      [
+        {
+          key: "deedPollFile",
+          type: "file",
+          title: "Deed poll",
+          category: "nameChange",
+        },
+      ],
+      {}
+    );
+  }
+  expect(callAttachFilesToMessage).rejects.toStrictEqual(new ApplicationError("FILE", "URL_INVALID", "url: undefined was invalid"));
+});

--- a/worker/src/queues/ses/workers/__tests__/sesSendHandler.test.ts
+++ b/worker/src/queues/ses/workers/__tests__/sesSendHandler.test.ts
@@ -1,0 +1,12 @@
+import { sesSendHandler } from "../sesSendHandler";
+import { ApplicationError } from "../../../../utils/ApplicationError";
+
+test("sesSendHandler throws an File application error if attachments are empty", async () => {
+  expect(
+    sesSendHandler({
+      data: {
+        attachments: [{}],
+      },
+    })
+  ).rejects.toEqual(new ApplicationError("FILE", "URL_INVALID", "url: undefined was invalid"));
+});

--- a/worker/src/utils/Errors.ts
+++ b/worker/src/utils/Errors.ts
@@ -24,7 +24,7 @@ export type ErrorTypes = "CONSUMER" | "FILE" | "GENERIC" | "SES";
  */
 type ConsumerErrorCode = "START_FAILED";
 type GenericErrorCode = "UNKNOWN";
-type FileErrorCode = "EMPTY_RES" | "ORIGIN_NOT_ALLOWED" | "API_ERROR" | "NOT_FOUND";
+type FileErrorCode = "EMPTY_RES" | "ORIGIN_NOT_ALLOWED" | "API_ERROR" | "NOT_FOUND" | "URL_INVALID";
 
 /**
  * Union of all the different ErrorCode.
@@ -51,6 +51,7 @@ const FILE: ErrorRecord<FileErrorCode> = {
   ORIGIN_NOT_ALLOWED: "The file is not located in an allowed origin",
   API_ERROR: "There was an error returning this file",
   NOT_FOUND: "The requested file could not be found",
+  URL_INVALID: "The url is invalid",
 };
 
 type ErrorRecords = {


### PR DESCRIPTION
If a URL is missing or invalid, an `ApplicationError` will be thrown with the new code `URL_INVALID`. 

Previously it was throwing an error (Cannot read properties of undefined) when reading url.origin (but without an error code that can be easily filtered by via cloud watch metrics)
