### PR TITLE
feat: Update docs list functionality to pass through specific variables instead for each for type

### DIFF
--- a/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder.ts
+++ b/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder.ts
@@ -1,4 +1,4 @@
-import { buildUserConfirmationPersonalisation } from "./personalisationBuilder.userConfirmation";
+import { buildUserConfirmationPersonalisation } from "./personalisationBuilder/userConfirmation";
 import { buildPostNotificationPersonalisation } from "./personalisationBuilder.postNotification";
 import { buildUserPostalConfirmationPersonalisation } from "./personalisationBuilder.userPostalConfirmation";
 

--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -2,7 +2,7 @@ import "pg-boss";
 import { testData } from "./fixtures";
 import { answersHashMap, flattenQuestions } from "../../../helpers";
 import { PersonalisationBuilder } from "../PersonalisationBuilder";
-import { getAffirmationPersonalisations, getCNIPersonalisations } from "../personalisationBuilder.userConfirmation";
+import { getAffirmationPersonalisations, getCNIPersonalisations } from "../personalisationBuilder/userConfirmation/getAdditionalPersonalisations";
 import { buildUserPostalConfirmationPersonalisation, getUserPostalConfirmationAdditionalContext } from "../personalisationBuilder.userPostalConfirmation";
 const pgBossMock = {
   async start() {

--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -2,7 +2,7 @@ import "pg-boss";
 import { testData } from "./fixtures";
 import { answersHashMap, flattenQuestions } from "../../../helpers";
 import { PersonalisationBuilder } from "../PersonalisationBuilder";
-import { buildUserConfirmationDocsList } from "../personalisationBuilder.userConfirmation";
+// import { buildUserConfirmationDocsList } from "../personalisationBuilder.userConfirmation";
 import { buildUserPostalConfirmationPersonalisation, getUserPostalConfirmationAdditionalContext } from "../personalisationBuilder.userPostalConfirmation";
 const pgBossMock = {
   async start() {
@@ -102,40 +102,40 @@ test("buildUserPostalConfirmationPersonalisation renders countries with default 
   expect(personalisation.post).toBe("the British Embassy Rome");
 });
 
-test("buildDocsList will add optional documents when the relevant fields are filled in", () => {
-  const answers = answersHashMap(formFields);
-  const fieldsMap = {
-    ...answers,
-    marriedBefore: true,
-    maritalStatus: "Divorced",
-    oathType: "Religious",
-  };
-  expect(buildUserConfirmationDocsList(fieldsMap, "affirmation")).toBe(
-    `* your UK passport\n* your birth certificate\n* proof of address – you must use your residence permit if the country you live in issues these\n* your partner’s passport or national identity card\n* decree absolute\n* religious book of your faith to swear upon`
-  );
-});
-
-test("buildDocsList will add cni proof of stay doc if the form type is cni and the user does not live in the country", () => {
-  const answers = answersHashMap(formFields);
-  const fieldsMap = {
-    ...answers,
-    marriedBefore: false,
-    oathType: "affirmation",
-  };
-  expect(buildUserConfirmationDocsList(fieldsMap, "cni")).toBe(
-    `* your UK passport\n* proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address\n* your partner’s passport or national identity card`
-  );
-});
-
-test("buildDocsList will add proof of address doc if the form type is cni and the user lives in the country", () => {
-  const answers = answersHashMap(formFields);
-  const fieldsMap = {
-    ...answers,
-    marriedBefore: false,
-    oathType: "affirmation",
-    livesInCountry: true,
-  };
-  expect(buildUserConfirmationDocsList(fieldsMap, "cni")).toBe(
-    `* your UK passport\n* proof of address – you must use your residence permit if the country you live in issues these\n* your partner’s passport or national identity card`
-  );
-});
+// test("buildDocsList will add optional documents when the relevant fields are filled in", () => {
+//   const answers = answersHashMap(formFields);
+//   const fieldsMap = {
+//     ...answers,
+//     marriedBefore: true,
+//     maritalStatus: "Divorced",
+//     oathType: "Religious",
+//   };
+//   expect(buildUserConfirmationDocsList(fieldsMap, "affirmation")).toBe(
+//     `* your UK passport\n* your birth certificate\n* proof of address – you must use your residence permit if the country you live in issues these\n* your partner’s passport or national identity card\n* decree absolute\n* religious book of your faith to swear upon`
+//   );
+// });
+//
+// test("buildDocsList will add cni proof of stay doc if the form type is cni and the user does not live in the country", () => {
+//   const answers = answersHashMap(formFields);
+//   const fieldsMap = {
+//     ...answers,
+//     marriedBefore: false,
+//     oathType: "affirmation",
+//   };
+//   expect(buildUserConfirmationDocsList(fieldsMap, "cni")).toBe(
+//     `* your UK passport\n* proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address\n* your partner’s passport or national identity card`
+//   );
+// });
+//
+// test("buildDocsList will add proof of address doc if the form type is cni and the user lives in the country", () => {
+//   const answers = answersHashMap(formFields);
+//   const fieldsMap = {
+//     ...answers,
+//     marriedBefore: false,
+//     oathType: "affirmation",
+//     livesInCountry: true,
+//   };
+//   expect(buildUserConfirmationDocsList(fieldsMap, "cni")).toBe(
+//     `* your UK passport\n* proof of address – you must use your residence permit if the country you live in issues these\n* your partner’s passport or national identity card`
+//   );
+// });

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -16,7 +16,6 @@ export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, me
     throw new ApplicationError("WEBHOOK", "VALIDATION", 500, "Fields are empty");
   }
   const additionalPersonalisations = personalisationTypeMap[metadata.type as string]?.(answers) ?? {};
-  // const docsList = buildUserConfirmationDocsList(answers, metadata.type);
   const country = answers["country"] as string;
   const post = answers["post"] as string;
 
@@ -55,37 +54,3 @@ export function getCNIPersonalisations(fields: AnswersHashMap) {
     religious: fields.oathType === "Religious",
   };
 }
-
-// export function buildUserConfirmationDocsList(fields: AnswersHashMap, type?: FormType) {
-//   if (!fields) {
-//     throw new ApplicationError("WEBHOOK", "VALIDATION", 500, "Fields are empty");
-//   }
-//
-//   const docsList = ["your UK passport", "your partner’s passport or national identity card"];
-//
-//   // for cni applications, proof of address is only required if the user lives in the country. For affirmation applications, proof of address is always required
-//   if (type === "affirmation" || (type === "cni" && fields.livesInCountry)) {
-//     docsList.splice(1, 0, "proof of address – you must use your residence permit if the country you live in issues these");
-//   }
-//
-//   // for cnis, the user needs to provide proof they have stayed in the country for 3 days. For contextual reasons, this should appear below the proof of address doc
-//   if (type === "cni" && !fields.livesInCountry) {
-//     docsList.splice(1, 0, "proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address");
-//   }
-//
-//   // for affirmations, users need to provide their birth certificate. For contextual reasons, this should appear next to the user's passport
-//   if (type === "affirmation") {
-//     docsList.splice(1, 0, "your birth certificate");
-//   }
-//
-//   if (fields.maritalStatus && fields.maritalStatus !== "Never married") {
-//     docsList.push(`${previousMarriageDocs[fields.maritalStatus as string]}`);
-//   }
-//   if (fields.oathType === "Religious") {
-//     docsList.push("religious book of your faith to swear upon");
-//   }
-//   const country = fields.country as string;
-//   const additionalDocs = additionalContexts.countries[country]?.additionalDocs ?? [];
-//   docsList.push(...additionalDocs);
-//   return docsList.map((doc) => `* ${doc}`).join("\n");
-// }

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -6,9 +6,12 @@ import { ApplicationError } from "../../../../ApplicationError";
 
 type PersonalisationFunction = (fields: AnswersHashMap) => Record<string, boolean>;
 
-const personalisationTypeMap: { [key in FormType]?: PersonalisationFunction } = {
+const personalisationTypeMap: Record<FormType, PersonalisationFunction> = {
   affirmation: getAffirmationPersonalisations,
   cni: getCNIPersonalisations,
+  exchange: (_fields: AnswersHashMap) => ({}),
+  msc: (_fields: AnswersHashMap) => ({}),
+  cniAndMsc: (_fields: AnswersHashMap) => ({}),
 };
 
 export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, metadata: { reference: string; payment?: PayMetadata; type?: FormType }) {

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -42,8 +42,8 @@ export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, me
 
 export function getAffirmationPersonalisations(fields: AnswersHashMap) {
   return {
-    previouslyMarried: fields.previouslyMarried !== "Never married",
-    religious: fields.oathType === "religious",
+    previouslyMarried: fields.maritalStatus !== "Never married",
+    religious: fields.oathType === "Religious",
   };
 }
 
@@ -51,8 +51,8 @@ export function getCNIPersonalisations(fields: AnswersHashMap) {
   return {
     livesInCountry: fields.livesInCountry === true,
     livesAbroad: !fields.livesInCountry,
-    previouslyMarried: fields.previouslyMarried !== "Never married",
-    religious: fields.oathType === "religious",
+    previouslyMarried: fields.maritalStatus !== "Never married",
+    religious: fields.oathType === "Religious",
   };
 }
 

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userConfirmation.ts
@@ -4,17 +4,19 @@ import { AnswersHashMap } from "../../../../types/AnswersHashMap";
 import { FormType, PayMetadata } from "../../../../types/FormDataBody";
 import { ApplicationError } from "../../../../ApplicationError";
 
-const previousMarriageDocs = {
-  Divorced: "decree absolute",
-  "Dissolved civil partner": "final order",
-  Widowed: "late partner's death certificate",
-  "Surviving civil partner": "late partner's death certificate",
-  Annulled: "decree of nullity",
+const personalisationTypeMap = {
+  affirmation: getAffirmationPersonalisations,
+  cni: getCNIPersonalisations,
 };
 
 export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, metadata: { reference: string; payment?: PayMetadata; type?: FormType }) {
   const isSuccessfulPayment = metadata.payment?.state?.status === "success" ?? false;
-  const docsList = buildUserConfirmationDocsList(answers, metadata.type);
+
+  if (!answers) {
+    throw new ApplicationError("WEBHOOK", "VALIDATION", 500, "Fields are empty");
+  }
+  const additionalPersonalisations = personalisationTypeMap[metadata.type as string]?.(answers) ?? {};
+  // const docsList = buildUserConfirmationDocsList(answers, metadata.type);
   const country = answers["country"] as string;
   const post = answers["post"] as string;
 
@@ -26,7 +28,6 @@ export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, me
   return {
     firstName: answers.firstName,
     post: getPost(country, post),
-    docsList,
     country,
     bookingLink: additionalContext.bookingLink,
     localRequirements: additionalContext.localRequirements,
@@ -34,39 +35,57 @@ export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, me
     reference: metadata.reference,
     confirmationDelay: additionalContext.confirmationDelay ?? "2 weeks",
     notPaid: !isSuccessfulPayment,
+    ...additionalPersonalisations,
+    additionalDocs: additionalContext.additionalDocs ?? "",
   };
 }
 
-export function buildUserConfirmationDocsList(fields: AnswersHashMap, type?: FormType) {
-  if (!fields) {
-    throw new ApplicationError("WEBHOOK", "VALIDATION", 500, "Fields are empty");
-  }
-
-  const docsList = ["your UK passport", "your partner’s passport or national identity card"];
-
-  // for cni applications, proof of address is only required if the user lives in the country. For affirmation applications, proof of address is always required
-  if (type === "affirmation" || (type === "cni" && fields.livesInCountry)) {
-    docsList.splice(1, 0, "proof of address – you must use your residence permit if the country you live in issues these");
-  }
-
-  // for cnis, the user needs to provide proof they have stayed in the country for 3 days. For contextual reasons, this should appear below the proof of address doc
-  if (type === "cni" && !fields.livesInCountry) {
-    docsList.splice(1, 0, "proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address");
-  }
-
-  // for affirmations, users need to provide their birth certificate. For contextual reasons, this should appear next to the user's passport
-  if (type === "affirmation") {
-    docsList.splice(1, 0, "your birth certificate");
-  }
-
-  if (fields.maritalStatus && fields.maritalStatus !== "Never married") {
-    docsList.push(`${previousMarriageDocs[fields.maritalStatus as string]}`);
-  }
-  if (fields.oathType === "Religious") {
-    docsList.push("religious book of your faith to swear upon");
-  }
-  const country = fields.country as string;
-  const additionalDocs = additionalContexts.countries[country]?.additionalDocs ?? [];
-  docsList.push(...additionalDocs);
-  return docsList.map((doc) => `* ${doc}`).join("\n");
+export function getAffirmationPersonalisations(fields: AnswersHashMap) {
+  return {
+    previouslyMarried: fields.previouslyMarried !== "Never married",
+    religious: fields.oathType === "religious",
+  };
 }
+
+export function getCNIPersonalisations(fields: AnswersHashMap) {
+  return {
+    livesInCountry: fields.livesInCountry === true,
+    livesAbroad: !fields.livesInCountry,
+    previouslyMarried: fields.previouslyMarried !== "Never married",
+    religious: fields.oathType === "religious",
+  };
+}
+
+// export function buildUserConfirmationDocsList(fields: AnswersHashMap, type?: FormType) {
+//   if (!fields) {
+//     throw new ApplicationError("WEBHOOK", "VALIDATION", 500, "Fields are empty");
+//   }
+//
+//   const docsList = ["your UK passport", "your partner’s passport or national identity card"];
+//
+//   // for cni applications, proof of address is only required if the user lives in the country. For affirmation applications, proof of address is always required
+//   if (type === "affirmation" || (type === "cni" && fields.livesInCountry)) {
+//     docsList.splice(1, 0, "proof of address – you must use your residence permit if the country you live in issues these");
+//   }
+//
+//   // for cnis, the user needs to provide proof they have stayed in the country for 3 days. For contextual reasons, this should appear below the proof of address doc
+//   if (type === "cni" && !fields.livesInCountry) {
+//     docsList.splice(1, 0, "proof you’ve been staying in the country for 3 whole days before your appointment – if this is not shown on your proof of address");
+//   }
+//
+//   // for affirmations, users need to provide their birth certificate. For contextual reasons, this should appear next to the user's passport
+//   if (type === "affirmation") {
+//     docsList.splice(1, 0, "your birth certificate");
+//   }
+//
+//   if (fields.maritalStatus && fields.maritalStatus !== "Never married") {
+//     docsList.push(`${previousMarriageDocs[fields.maritalStatus as string]}`);
+//   }
+//   if (fields.oathType === "Religious") {
+//     docsList.push("religious book of your faith to swear upon");
+//   }
+//   const country = fields.country as string;
+//   const additionalDocs = additionalContexts.countries[country]?.additionalDocs ?? [];
+//   docsList.push(...additionalDocs);
+//   return docsList.map((doc) => `* ${doc}`).join("\n");
+// }

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userConfirmation/getAdditionalPersonalisations.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userConfirmation/getAdditionalPersonalisations.ts
@@ -1,0 +1,28 @@
+import { AnswersHashMap } from "../../../../../../types/AnswersHashMap";
+import { FormType } from "../../../../../../types/FormDataBody";
+
+type PersonalisationFunction = (fields: AnswersHashMap) => Record<string, boolean>;
+
+export const personalisationTypeMap: Record<FormType, PersonalisationFunction> = {
+  affirmation: getAffirmationPersonalisations,
+  cni: getCNIPersonalisations,
+  exchange: (_fields: AnswersHashMap) => ({}),
+  msc: (_fields: AnswersHashMap) => ({}),
+  cniAndMsc: (_fields: AnswersHashMap) => ({}),
+};
+
+export function getAffirmationPersonalisations(fields: AnswersHashMap) {
+  return {
+    previouslyMarried: fields.maritalStatus !== "Never married",
+    religious: fields.oathType === "Religious",
+  };
+}
+
+export function getCNIPersonalisations(fields: AnswersHashMap) {
+  return {
+    livesInCountry: fields.livesInCountry === true,
+    livesAbroad: !fields.livesInCountry,
+    previouslyMarried: fields.maritalStatus !== "Never married",
+    religious: fields.oathType === "Religious",
+  };
+}

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userConfirmation/index.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userConfirmation/index.ts
@@ -1,18 +1,9 @@
-import * as additionalContexts from "./../../utils/additionalContexts.json";
-import { getPost } from "../../utils/getPost";
-import { AnswersHashMap } from "../../../../types/AnswersHashMap";
-import { FormType, PayMetadata } from "../../../../types/FormDataBody";
-import { ApplicationError } from "../../../../ApplicationError";
-
-type PersonalisationFunction = (fields: AnswersHashMap) => Record<string, boolean>;
-
-const personalisationTypeMap: Record<FormType, PersonalisationFunction> = {
-  affirmation: getAffirmationPersonalisations,
-  cni: getCNIPersonalisations,
-  exchange: (_fields: AnswersHashMap) => ({}),
-  msc: (_fields: AnswersHashMap) => ({}),
-  cniAndMsc: (_fields: AnswersHashMap) => ({}),
-};
+import { AnswersHashMap } from "../../../../../../types/AnswersHashMap";
+import { FormType, PayMetadata } from "../../../../../../types/FormDataBody";
+import { ApplicationError } from "../../../../../../ApplicationError";
+import * as additionalContexts from "../../../../utils/additionalContexts.json";
+import { getPost } from "../../../../utils/getPost";
+import { personalisationTypeMap } from "./getAdditionalPersonalisations";
 
 export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, metadata: { reference: string; payment?: PayMetadata; type?: FormType }) {
   const isSuccessfulPayment = metadata.payment?.state?.status === "success" ?? false;
@@ -21,7 +12,7 @@ export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, me
     throw new ApplicationError("WEBHOOK", "VALIDATION", 500, "Fields are empty");
   }
 
-  const getAdditionalPersonalisations = personalisationTypeMap[metadata.type as string];
+  const getAdditionalPersonalisations = personalisationTypeMap[metadata.type!];
   if (!getAdditionalPersonalisations) {
     throw new ApplicationError("WEBHOOK", "VALIDATION", 500, `No personalisation mapper set for form type: ${metadata.type}`);
   }
@@ -47,21 +38,5 @@ export function buildUserConfirmationPersonalisation(answers: AnswersHashMap, me
     notPaid: !isSuccessfulPayment,
     ...additionalPersonalisations,
     additionalDocs: additionalContext.additionalDocs ?? "",
-  };
-}
-
-export function getAffirmationPersonalisations(fields: AnswersHashMap) {
-  return {
-    previouslyMarried: fields.maritalStatus !== "Never married",
-    religious: fields.oathType === "Religious",
-  };
-}
-
-export function getCNIPersonalisations(fields: AnswersHashMap) {
-  return {
-    livesInCountry: fields.livesInCountry === true,
-    livesAbroad: !fields.livesInCountry,
-    previouslyMarried: fields.maritalStatus !== "Never married",
-    religious: fields.oathType === "Religious",
   };
 }


### PR DESCRIPTION
Previously the way the docs list was compiled for each form used a specific `buildDocsList` function, which would use the answers from the form as well as some extra information about the form to compile a list of bullet points to send to GOV.UK Notify.

However as the forms have developed, we've realised that the requirements of each list have diverged, and it's caused more overhead by keeping them in the same function instead of splitting them out into separate functions and passing through separate variables instead.

each form with a variable docs list now sends through some additionalPersonalisations, and these are calculated in `getAffirmationPersonalisations` and `getCNIPersonalisations`.