### PR TITLE
feat: Added custom content to emails for Croatia 

### DIFF
--- a/api/src/middlewares/services/UserService/__tests__/getUserTemplate.test.ts
+++ b/api/src/middlewares/services/UserService/__tests__/getUserTemplate.test.ts
@@ -14,6 +14,10 @@ jest.mock("../../utils/additionalContexts.json", () => {
         postal: true,
         cniDelivery: false,
       },
+      Croatia: {
+        postal: true,
+        cniDelivery: true,
+      },
     },
   };
 });

--- a/api/src/middlewares/services/UserService/__tests__/getUserTemplate.test.ts
+++ b/api/src/middlewares/services/UserService/__tests__/getUserTemplate.test.ts
@@ -41,3 +41,7 @@ test("returns correct template from country if the form has no postal metadata, 
 test("returns correct template from country if the form has no postal metadata, the user is submitting an exchange, and the country does not allow postal exchange", () => {
   expect(getUserTemplate("Russia", "exchange")).toBe("userConfirmation");
 });
+
+test("returns the correct template for exchange if the country is Croatia", () => {
+  expect(getUserTemplate("Croatia", "exchange")).toBe("userConfirmation");
+});

--- a/api/src/middlewares/services/UserService/getUserTemplate.ts
+++ b/api/src/middlewares/services/UserService/getUserTemplate.ts
@@ -2,7 +2,14 @@ import * as additionalContexts from "../utils/additionalContexts.json";
 import { FormType } from "../../../types/FormDataBody";
 
 export function getUserTemplate(country: string, type: FormType, postal?: boolean) {
-  const postalSupport = postal ?? (type === "exchange" && additionalContexts.countries[country]?.postal && additionalContexts.countries[country]?.cniDelivery);
+  // for exchange forms, any country that offers a postal journey and cni delivery should be a postal application.
+  const countryOffersPostalRoute = additionalContexts.countries[country]?.postal && additionalContexts.countries[country]?.cniDelivery;
+
+  // Croatia is an exception to this, and only offers in-person applications for exchange
+  const countryIsCroatia = country === "Croatia";
+
+  const postalSupport = postal ?? (type === "exchange" && countryOffersPostalRoute && !countryIsCroatia);
+
   if (!postalSupport) {
     return "userConfirmation";
   }

--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -44,6 +44,7 @@ test("buildSendEmailArgs should return the correct personalisation for a postal 
     firstName: "foo",
     post: "the British Consulate General Istanbul",
     country: "Turkey",
+    croatiaCertNeeded: false,
     bookingLink: "https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=67&service=13",
     localRequirements: "",
     civilPartnership: false,
@@ -132,9 +133,11 @@ test("getCNIPersonalisations returns the correct personalisations given all posi
     livesInCountry: true,
     maritalStatus: "Divorced",
     oathType: "Religious",
+    certRequired: true,
   };
 
   expect(getCNIPersonalisations(answers)).toStrictEqual({
+    croatiaCertNeeded: true,
     livesInCountry: true,
     livesAbroad: false,
     previouslyMarried: true,
@@ -147,9 +150,11 @@ test("getCNIPersonalisations returns the correct personalisations given all nega
     livesInCountry: false,
     maritalStatus: "Never married",
     oathType: "Non-religious",
+    certRequired: false,
   };
 
   expect(getCNIPersonalisations(answers)).toStrictEqual({
+    croatiaCertNeeded: false,
     livesInCountry: false,
     livesAbroad: true,
     previouslyMarried: false,

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userPostalConfirmation.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.userPostalConfirmation.ts
@@ -23,6 +23,9 @@ export function buildUserPostalConfirmationPersonalisation(answers: AnswersHashM
   const partnerHasPreviousMarriage = answers.partnerMaritalStatus && answers.partnerMaritalStatus !== "Never married";
   const italyPartnerPreviousMarriage = country === "Italy" && partnerHasPreviousMarriage;
 
+  // For Croatia, there is an additional question asking if the user needs a certificate of custom law. If the answer is yes, they will need to provide this with their postal application
+  const croatiaCertNeeded = answers.certRequired === true;
+
   const additionalContext = getUserPostalConfirmationAdditionalContext(country, post);
 
   return {
@@ -34,6 +37,7 @@ export function buildUserPostalConfirmationPersonalisation(answers: AnswersHashM
     civilPartnership: additionalContext.civilPartnership,
     previousMarriage,
     italyPartnerPreviousMarriage,
+    croatiaCertNeeded,
     reference: metadata.reference,
     postAddress: additionalContext.postAddress,
     notPaid: !isSuccessfulPayment,

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userConfirmation/getAdditionalPersonalisations.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userConfirmation/getAdditionalPersonalisations.ts
@@ -6,7 +6,7 @@ type PersonalisationFunction = (fields: AnswersHashMap) => Record<string, boolea
 export const personalisationTypeMap: Record<FormType, PersonalisationFunction> = {
   affirmation: getAffirmationPersonalisations,
   cni: getCNIPersonalisations,
-  exchange: (_fields: AnswersHashMap) => ({}),
+  exchange: getExchangePersonalisations,
   msc: (_fields: AnswersHashMap) => ({}),
   cniAndMsc: (_fields: AnswersHashMap) => ({}),
 };
@@ -24,5 +24,12 @@ export function getCNIPersonalisations(fields: AnswersHashMap) {
     livesAbroad: !fields.livesInCountry,
     previouslyMarried: fields.maritalStatus !== "Never married",
     religious: fields.oathType === "Religious",
+    croatiaCertNeeded: fields.certRequired === true,
+  };
+}
+
+export function getExchangePersonalisations(fields: AnswersHashMap) {
+  return {
+    croatiaCertNeeded: fields.certRequired === true,
   };
 }


### PR DESCRIPTION
Croatia requires an extra document - a certificate of custom law. As Croatia is a low volume country, it doesn't make sense to create an entirely new service for Croatia like we have done for Spain and their marital status certificate.

As a compromise, we have added a couple of extra fields to the service allowing the user to upload a separate application form for their certificate of custom law. If this has been uploaded, the user will need to bring this application. form with them to their appointment, or send the notarised form in their postal application. This bullet has been added to the relevant emails in GOV.UK Notify, and the additionalPersonalisation functions have been updated to reflect this.

In addition to this extra content, Croatia also has a requirement for their exchange applications to be in-person, despite offering a hybrid postal service. With this in mind, the `getUserTemplate` function has been updated to have an override to force the in-person exchange confirmation email to be sent instead of the postal exchange confirmation email.