### PR TITLE
feat: Add reference number to post notification email personalisation

### DIFF
--- a/api/src/middlewares/services/StaffService/StaffService.ts
+++ b/api/src/middlewares/services/StaffService/StaffService.ts
@@ -170,7 +170,7 @@ export class StaffService {
     const country = answers["country"] as string;
     const post = answers["post"] as string;
     const emailAddress = getPostEmailAddress(country, post);
-    const personalisation = PersonalisationBuilder.postNotification(answers, type);
+    const personalisation = PersonalisationBuilder.postNotification(answers, type, reference);
     if (!emailAddress) {
       this.logger.error(
         { code: "UNRECOGNISED_SERVICE_APPLICATION" },

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.postNotification.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder.postNotification.ts
@@ -24,13 +24,14 @@ const personalisationMappings: Record<FormType, object> = {
     caseType: "a CNI and MSC",
   },
 };
-export function buildPostNotificationPersonalisation(answers: AnswersHashMap, type: FormType) {
+export function buildPostNotificationPersonalisation(answers: AnswersHashMap, type: FormType, reference: string) {
   const country = answers["country"] as string;
   const post = (answers["post"] ?? additionalContexts.countries?.[country]?.post) as string;
 
   return {
     post,
     type,
+    reference,
     ...personalisationMappings[type],
   };
 }


### PR DESCRIPTION
If for some reason a post can't find a submission email in the global shared mailbox, it can help to pass through the reference number for the form that's been submitted for the post notification email. That way, the post will be able to find the relevant submission email by reference number, and if not, we know that the submission email has somehow been lost.