### PR TITLE
feat: add fields for local and permanent address to cni and msc remappers

### DIFF
--- a/api/src/middlewares/services/StaffService/__tests__/__snapshots__/remappers.test.ts.snap
+++ b/api/src/middlewares/services/StaffService/__tests__/__snapshots__/remappers.test.ts.snap
@@ -143,13 +143,6 @@ exports[`CNIAndMSC is successfully remapped 1`] = `
       "type": "list",
     },
   },
-  "livesInCountry": {
-    "answer": true,
-    "category": "applicantDetails",
-    "key": "livesInCountry",
-    "title": "Lives in the country",
-    "type": "list",
-  },
   "maritalStatus": {
     "status": {
       "answer": "Never married",
@@ -278,6 +271,15 @@ exports[`CNIAndMSC is successfully remapped 1`] = `
     "key": "placeOfBirth",
     "title": "Place of birth ",
     "type": "text",
+  },
+  "residentStatus": {
+    "isAResidentOfApplicationCountry": {
+      "answer": true,
+      "category": "applicantDetails",
+      "key": "livesInCountry",
+      "title": "Lives in the country",
+      "type": "list",
+    },
   },
   "service": {
     "answer": "cniAndMsc",
@@ -694,13 +696,6 @@ exports[`cniPostal is successfully remapped 1`] = `
       "type": "list",
     },
   },
-  "livesInCountry": {
-    "answer": true,
-    "category": "applicantDetails",
-    "key": "livesInCountry",
-    "title": "Lives in the country",
-    "type": "list",
-  },
   "maritalStatus": {
     "status": {
       "answer": "Never married",
@@ -808,6 +803,15 @@ exports[`cniPostal is successfully remapped 1`] = `
       "category": "partner",
       "key": "partnerNationality",
       "title": "Partner’s nationality",
+      "type": "list",
+    },
+  },
+  "residentStatus": {
+    "isAResidentOfApplicationCountry": {
+      "answer": true,
+      "category": "applicantDetails",
+      "key": "livesInCountry",
+      "title": "Lives in the country",
       "type": "list",
     },
   },
@@ -1133,13 +1137,6 @@ exports[`msc is successfully remapped 1`] = `
       "type": "list",
     },
   },
-  "livesInCountry": {
-    "answer": true,
-    "category": "applicantDetails",
-    "key": "livesInCountry",
-    "title": "Lives in the country",
-    "type": "list",
-  },
   "maritalStatus": {
     "status": {
       "answer": "Never married",
@@ -1190,6 +1187,15 @@ exports[`msc is successfully remapped 1`] = `
     "key": "placeOfBirth",
     "title": "Place of birth ",
     "type": "text",
+  },
+  "residentStatus": {
+    "isAResidentOfApplicationCountry": {
+      "answer": true,
+      "category": "applicantDetails",
+      "key": "livesInCountry",
+      "title": "Lives in the country",
+      "type": "list",
+    },
   },
   "service": {
     "answer": "msc",

--- a/api/src/middlewares/services/StaffService/__tests__/__snapshots__/reorderers.test.ts.snap
+++ b/api/src/middlewares/services/StaffService/__tests__/__snapshots__/reorderers.test.ts.snap
@@ -2,43 +2,6 @@
 
 exports[`CNI and MSC by post is successfully remapped 1`] = `
 {
-  "Applicant's address": {
-    "addressLine1": {
-      "answer": "test",
-      "category": "applicantDetails",
-      "key": "addressLine1",
-      "title": "Address line 1",
-      "type": "text",
-    },
-    "addressLine2": {
-      "answer": null,
-      "category": "applicantDetails",
-      "key": "addressLine2",
-      "title": "Address line 2 ",
-      "type": "text",
-    },
-    "city": {
-      "answer": "test",
-      "category": "applicantDetails",
-      "key": "city",
-      "title": "Town or city",
-      "type": "text",
-    },
-    "country": {
-      "answer": "United Kingdom",
-      "category": "applicantDetails",
-      "key": "countryAddress",
-      "title": "Country",
-      "type": "list",
-    },
-    "postcode": {
-      "answer": null,
-      "category": "applicantDetails",
-      "key": "postcode",
-      "title": "Postcode or zip code",
-      "type": "text",
-    },
-  },
   "Applicant's details": {
     "dateOfBirth": {
       "answer": "1998-01-19",
@@ -90,6 +53,7 @@ exports[`CNI and MSC by post is successfully remapped 1`] = `
       "type": "text",
     },
   },
+  "Applicant's local address": undefined,
   "Applicant's passport": {
     "dateOfIssue": {
       "answer": "1998-01-19",
@@ -106,6 +70,44 @@ exports[`CNI and MSC by post is successfully remapped 1`] = `
       "type": "text",
     },
   },
+  "Applicant's permanent address": {
+    "addressLine1": {
+      "answer": "test",
+      "category": "applicantDetails",
+      "key": "addressLine1",
+      "title": "Address line 1",
+      "type": "text",
+    },
+    "addressLine2": {
+      "answer": null,
+      "category": "applicantDetails",
+      "key": "addressLine2",
+      "title": "Address line 2 ",
+      "type": "text",
+    },
+    "city": {
+      "answer": "test",
+      "category": "applicantDetails",
+      "key": "city",
+      "title": "Town or city",
+      "type": "text",
+    },
+    "country": {
+      "answer": "United Kingdom",
+      "category": "applicantDetails",
+      "key": "countryAddress",
+      "title": "Country",
+      "type": "list",
+    },
+    "postcode": {
+      "answer": null,
+      "category": "applicantDetails",
+      "key": "postcode",
+      "title": "Postcode or zip code",
+      "type": "text",
+    },
+  },
+  "Applicant's residential status": undefined,
   "Delivery details": undefined,
   "Feedback consent": {
     "feedbackConsent": {
@@ -663,6 +665,7 @@ exports[`MSC by post is successfully remapped 1`] = `
       "type": "list",
     },
   },
+  "Applicant's local address": undefined,
   "Applicant's passport": {
     "dateOfIssue": {
       "answer": "1998-01-19",
@@ -679,6 +682,8 @@ exports[`MSC by post is successfully remapped 1`] = `
       "type": "text",
     },
   },
+  "Applicant's permanent address": undefined,
+  "Applicant's residential status": undefined,
   "Delivery details": undefined,
   "Feedback consent": {
     "feedbackConsent": {

--- a/api/src/middlewares/services/StaffService/mappings/CNIAndMSC.ts
+++ b/api/src/middlewares/services/StaffService/mappings/CNIAndMSC.ts
@@ -1,6 +1,8 @@
 export const order = {
   applicantDetails: "Applicant's details",
-  applicantAddress: "Applicant's address",
+  residentStatus: "Applicant's residential status",
+  applicantAddress: "Applicant's permanent address",
+  applicantLocalAddress: "Applicant's local address",
   applicantPassport: "Applicant's passport",
   maritalStatus: "Marital and civil status",
   partnerName: "Partner's name",
@@ -26,11 +28,18 @@ export const remap = {
   emailAddress: "applicantDetails.emailAddress",
   phoneNumber: "applicantDetails.phoneNumber",
 
+  livesInCountry: "residentStatus.isAResidentOfApplicationCountry",
+
   addressLine1: "applicantAddress.addressLine1",
   addressLine2: "applicantAddress.addressLine2",
   city: "applicantAddress.city",
   postcode: "applicantAddress.postcode",
   countryAddress: "applicantAddress.country",
+
+  localAddressLine1: "applicantLocalAddress.addressLine1",
+  localAddressLine2: "applicantLocalAddress.addressLine2",
+  localCity: "applicantLocalAddress.city",
+  localPostcode: "applicantLocalAddress.postcode",
 
   passportDateOfIssue: "applicantPassport.dateOfIssue",
   passportNumber: "applicantPassport.number",

--- a/api/src/middlewares/services/StaffService/mappings/cniPostal.ts
+++ b/api/src/middlewares/services/StaffService/mappings/cniPostal.ts
@@ -1,6 +1,8 @@
 export const order = {
   applicantDetails: "Applicant's details",
-  applicantAddress: "Applicant's address",
+  residentStatus: "Applicant's residential status",
+  applicantAddress: "Applicant's permanent address",
+  applicantLocalAddress: "Applicant's local address",
   maritalStatus: "Marital and civil status",
   partnerName: "Partner's name",
   partnerAddress: "Partner's address",
@@ -23,11 +25,18 @@ export const remap = {
   emailAddress: "applicantDetails.emailAddress",
   phoneNumber: "applicantDetails.phoneNumber",
 
+  livesInCountry: "residentStatus.isAResidentOfApplicationCountry",
+
   addressLine1: "applicantAddress.addressLine1",
   addressLine2: "applicantAddress.addressLine2",
   city: "applicantAddress.city",
   postcode: "applicantAddress.postcode",
   countryAddress: "applicantAddress.country",
+
+  localAddressLine1: "applicantLocalAddress.addressLine1",
+  localAddressLine2: "applicantLocalAddress.addressLine2",
+  localCity: "applicantLocalAddress.city",
+  localPostcode: "applicantLocalAddress.postcode",
 
   maritalStatus: "maritalStatus.status",
 

--- a/api/src/middlewares/services/StaffService/mappings/msc.ts
+++ b/api/src/middlewares/services/StaffService/mappings/msc.ts
@@ -1,5 +1,8 @@
 export const order = {
   applicantDetails: "Applicant's details",
+  residentStatus: "Applicant's residential status",
+  applicantAddress: "Applicant's permanent address",
+  applicantLocalAddress: "Applicant's local address",
   applicantPassport: "Applicant's passport",
   maritalStatus: "Marital and civil status",
   marriageDetails: "Marriage",
@@ -20,6 +23,19 @@ export const remap = {
 
   passportDateOfIssue: "applicantPassport.dateOfIssue",
   passportNumber: "applicantPassport.number",
+
+  livesInCountry: "residentStatus.isAResidentOfApplicationCountry",
+
+  addressLine1: "applicantAddress.addressLine1",
+  addressLine2: "applicantAddress.addressLine2",
+  city: "applicantAddress.city",
+  postcode: "applicantAddress.postcode",
+  countryAddress: "applicantAddress.country",
+
+  localAddressLine1: "applicantLocalAddress.addressLine1",
+  localAddressLine2: "applicantLocalAddress.addressLine2",
+  localCity: "applicantLocalAddress.city",
+  localPostcode: "applicantLocalAddress.postcode",
 
   maritalStatus: "maritalStatus.status",
 


### PR DESCRIPTION
For applying for a cni by post, if the user lives outside the country they're applying for, they must supply the address of their accommodation where they stayed for 3 days before their notary appointment to confirm the notarising was carried out properly.

Whether the user lives in the country is now passed through to make it more obvious to posts which address should be used for the notice of marriage. The normal address fields have been renamed to "applicant's permanent address" to distinguish between the two addresses for MSC applications. Postal variants now pass through local address details as well.