### PR TITLE
fix: add missing personalisations for CNI by post email

### DIFF
--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -41,6 +41,7 @@ test("buildSendEmailArgs should return the correct personalisation for an in-per
 test("buildSendEmailArgs should return the correct personalisation for a postal email", () => {
   const personalisation = PersonalisationBuilder.userPostalConfirmation(answers, { reference: "1234" });
   expect(personalisation).toEqual({
+    additionalDocs: "",
     firstName: "foo",
     post: "the British Consulate General Istanbul",
     country: "Turkey",
@@ -50,6 +51,7 @@ test("buildSendEmailArgs should return the correct personalisation for a postal 
     reference: "1234",
     postAddress: "",
     userHadPreviousMarriage: false,
+    livesInCountry: false,
     livesOutsideApplicationCountry: false,
     partnerHadPreviousMarriage: true,
     notPaid: true,
@@ -65,10 +67,15 @@ test("buildSendEmailArgs should return the correct personalisation for Spain whe
   };
   const personalisation = PersonalisationBuilder.userPostalConfirmation(spainAnswers, { reference: "1234" });
   expect(personalisation).toEqual({
+    additionalDocs: [
+      "partner's proof any previous marriages or civil partnerships have ended",
+      "if you live in Spain, registration certificate for the town hall register (padrón municipal) – also use as proof of address",
+    ],
     firstName: "foo",
     post: "the British Consulate General Istanbul",
     country: "Spain",
     bookingLink: "https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=67&service=13",
+    livesInCountry: true,
     livesOutsideApplicationCountry: false,
     localRequirements:
       "\nYou must apply for your documents 3 months before your civil registry appointment, or your wedding date if you're holding a religious ceremony first and registering the marriage at the civil registry afterwards.  \nOnce the British Consulate General Madrid gets your correct documents in the post, you should get your documents within 30 working days. Your application cannot be processed any faster, even if your civil registry appointment or wedding date is closer. \nThe British Consulate General Madrid is unable to provide updates on the status of your application.",
@@ -82,17 +89,24 @@ test("buildSendEmailArgs should return the correct personalisation for Spain whe
 });
 
 test("buildSendEmailArgs should return the correct personalisation for Italy when the user's partner has been married before", () => {
-  const spainAnswers = {
+  const italyAnswers = {
     ...answers,
     country: "Italy",
     partnerMaritalStatus: "Divorced",
+    livesInCountry: true,
   };
-  const personalisation = PersonalisationBuilder.userPostalConfirmation(spainAnswers, { reference: "1234" });
+  const personalisation = PersonalisationBuilder.userPostalConfirmation(italyAnswers, { reference: "1234" });
   expect(personalisation).toEqual({
+    additionalDocs: [
+      "your parents' full names ",
+      "partner's proof any previous marriages or civil partnerships have ended",
+      "proof of address if you live in the UK",
+    ],
     firstName: "foo",
     post: "the British Consulate General Istanbul",
     country: "Italy",
     bookingLink: "https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=67&service=13",
+    livesInCountry: true,
     livesOutsideApplicationCountry: false,
     localRequirements:
       "\nA CNI is equivalent to a 'Nulla Osta' in Italy. \nIf you decide to apply by post, you will pay an additional fee to a notary public. ‘Ask the notary to use the 'Vera di Firma procedure’.",

--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userPostalConfirmation/index.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userPostalConfirmation/index.ts
@@ -18,6 +18,7 @@ export function buildUserPostalConfirmationPersonalisation(answers: AnswersHashM
   const country = answers["country"] as string;
   const post = answers["post"] as string;
   const userHadPreviousMarriage = answers.maritalStatus !== "Never married";
+  const livesInCountry = answers.livesInCountry === true;
   const livesOutsideApplicationCountry = answers.livesInCountry === false;
   const partnerHadPreviousMarriage = answers.partnerMaritalStatus !== "Never married";
 
@@ -31,10 +32,12 @@ export function buildUserPostalConfirmationPersonalisation(answers: AnswersHashM
     localRequirements: additionalContext.localRequirements,
     civilPartnership: additionalContext.civilPartnership,
     userHadPreviousMarriage,
+    livesInCountry,
     livesOutsideApplicationCountry,
     partnerHadPreviousMarriage,
     reference: metadata.reference,
     postAddress: additionalContext.postAddress,
     notPaid: !isSuccessfulPayment,
+    additionalDocs: additionalContext.additionalDocs,
   };
 }


### PR DESCRIPTION
Additional documents should now be being passed through to the postal email, as well whether the user lives in the application country.