### PR TITLE
fix: add "UK CNI issued by a UK register office" to affirmation email

### DIFF
--- a/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userConfirmation/getAdditionalDocsForCountry.ts
+++ b/api/src/middlewares/services/UserService/personalisation/personalisationBuilder/userConfirmation/getAdditionalDocsForCountry.ts
@@ -6,8 +6,8 @@ type Metadata = { type: FormType; reference: string; payment?: PayMetadata };
 export const getAdditionalDocsForCountry = {
   Montenegro: (_answers: AnswersHashMap, _additionalContext, metadata: Metadata) => {
     if (metadata?.type === "affirmation") {
-      return [];
+      return ["UK CNI issued by a UK register office"];
     }
-    return ["UK CNI issued by a UK register office"];
+    return [];
   },
 };


### PR DESCRIPTION
This should only show up for Montenegro affirmation journeys