### PR TITLE
chore: update circleci versions to working versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
         type: string
 
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:202111-02
 
     steps:
       - attach_workspace:


### PR DESCRIPTION
Previously we were using `ubuntu-2004:202201-02` for one of the build processes, we should've been using `ubuntu-2004:202111-02` though. This has been updated now 