### PR TITLE
fix: change getTemplate function to handle cni confirmation emails properly

### DIFF
--- a/api/src/middlewares/services/UserService/UserService.ts
+++ b/api/src/middlewares/services/UserService/UserService.ts
@@ -109,8 +109,8 @@ export class UserService {
   }
 
   getTemplate({ answers, type, postalVariant }: { answers: AnswersHashMap; type: FormType; postalVariant: "postal" | "inPerson" }) {
-    if (answers.service) {
-      return this.templates.cni[answers.service as MarriageTemplateType][postalVariant];
+    if (type === "cni") {
+      return this.templates.cni[(answers.service as MarriageTemplateType) ?? "cni"][postalVariant];
     }
     if (answers.over16 !== undefined) {
       const certifyCopyVariant = answers.over16 ? "adult" : "child";


### PR DESCRIPTION
Due to the new nesting of the cni user templates, the cni template was being missed in the in-person form. This has been changed so that `getTemplate` checks to see if the type is `cni`, and if so, gets the nested template.