### PR TITLE
fix: last UAT fixes before longtail release

### DIFF
--- a/api/src/middlewares/services/UserService/NotifyTemplates/CertifyCopyUserTemplates.ts
+++ b/api/src/middlewares/services/UserService/NotifyTemplates/CertifyCopyUserTemplates.ts
@@ -26,7 +26,7 @@ export class CertifyCopyUserTemplates implements UserTemplateGroup {
     const answers = data.answers as CertifyCopyAnswersHashmap;
     const isPostalApplication = answers.applicationType === "postal";
     const postalVariant: PostalVariant = isPostalApplication ? "postal" : "inPerson";
-    const isAdult = answers.over16 || false;
+    const isAdult = answers.over18 || false;
     const userTypeVariant = isAdult ? "adult" : "child";
     const personalisationBuilder = CertifyCopyPersonalisationBuilder[postalVariant];
 

--- a/api/src/middlewares/services/UserService/__tests__/userService.test.ts
+++ b/api/src/middlewares/services/UserService/__tests__/userService.test.ts
@@ -71,10 +71,10 @@ describe("sendEmailToUser - Marriage templates", () => {
 describe("sendEmailToUser - certifyCopy", () => {
   test.each`
     label                 | answers                                         | template
-    ${"adult - inPerson"} | ${{ over16: true }}                             | ${"certify-copy-adult-template"}
-    ${"adult - postal"}   | ${{ over16: true, applicationType: "postal" }}  | ${"certify-copy-adult-postal-template"}
-    ${"child - inPerson"} | ${{ over16: false }}                            | ${"certify-copy-child-template"}
-    ${"adult - postal"}   | ${{ over16: false, applicationType: "postal" }} | ${"certify-copy-child-postal-template"}
+    ${"adult - inPerson"} | ${{ over18: true }}                             | ${"certify-copy-adult-template"}
+    ${"adult - postal"}   | ${{ over18: true, applicationType: "postal" }}  | ${"certify-copy-adult-postal-template"}
+    ${"child - inPerson"} | ${{ over18: false }}                            | ${"certify-copy-child-template"}
+    ${"adult - postal"}   | ${{ over18: false, applicationType: "postal" }} | ${"certify-copy-child-postal-template"}
   `(`$template is returned for $label`, async ({ answers, template }) => {
     const metadata = { reference: "ref", type: "certifyCopy" };
     await userService.sendEmailToUser({ answers, metadata });

--- a/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder/certifyCopy/personalisationBuilder.inPerson.ts
+++ b/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder/certifyCopy/personalisationBuilder.inPerson.ts
@@ -14,6 +14,7 @@ export function buildInPersonPersonalisation(answers: AnswersHashMap, metadata: 
 
   const additionalContext = {
     ...(additionalContexts.certifyCopy.countries[country] ?? {}),
+    ...(additionalContexts.certifyCopy.posts[post] ?? {}),
   };
 
   return {

--- a/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder/certifyCopy/personalisationBuilder.postal.ts
+++ b/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder/certifyCopy/personalisationBuilder.postal.ts
@@ -9,6 +9,7 @@ export function buildPostalPersonalisation(answers: AnswersHashMap, metadata: { 
 
   const additionalContext = {
     ...(additionalContexts.certifyCopy.countries[country] ?? {}),
+    ...(additionalContexts.certifyCopy.posts[post] ?? {}),
   };
 
   return {


### PR DESCRIPTION
Fixed some issues before go-live:

- pulling through post additional contexts for certify a copy multiple embassies
- Changed `over16` field name to `over18` to match frontend