### PR TITLE
Send case team emails as fallback for Orbit

### DIFF
--- a/api/src/middlewares/services/SubmitService/SubmitService.ts
+++ b/api/src/middlewares/services/SubmitService/SubmitService.ts
@@ -47,7 +47,7 @@ export class SubmitService {
     const formFields = flattenQuestions(questions);
     const answers = answersHashMap(formFields);
     const { pay, type } = metadata;
-    const reference = metadata?.pay?.reference ?? this.generateId();
+    const reference = metadata?.externalReference ?? metadata?.internalReference ?? metadata?.pay?.reference ?? this.generateId();
     const caseServiceName = getCaseServiceName(type);
     if (pay) {
       pay.total = fees?.total;

--- a/api/src/middlewares/services/SubmitService/SubmitService.ts
+++ b/api/src/middlewares/services/SubmitService/SubmitService.ts
@@ -61,8 +61,12 @@ export class SubmitService {
         type,
         metadata,
       });
-      const caseProcessJob = await caseService.sendToProcessQueue(processQueueData);
-      this.logger.info({ reference, caseProcessJob }, `SES_PROCESS job queued successfully for ${reference}`);
+
+      // only email case team when there is no external reference (i.e. from Orbit) indicating a submission failure there
+      if (!metadata?.externalReference) {
+        const caseProcessJob = await caseService.sendToProcessQueue(processQueueData);
+        this.logger.info({reference, caseProcessJob}, `SES_PROCESS job queued successfully for ${reference}`);
+      }
 
       const userProcessJob = await this.userService.sendToProcessQueue(answers, { reference, payment: metadata.pay, type, postal: metadata.postal });
 

--- a/api/src/middlewares/validate.ts
+++ b/api/src/middlewares/validate.ts
@@ -19,7 +19,7 @@ const questionSchema = joi.object().keys({
 const webhookOutputSchema = joi.object().keys({
   name: joi.string().required(),
   questions: joi.array().items(questionSchema).required(),
-  fees: joi.object().optional(),
+  fees: joi.object().optional().allow(null),
   metadata: joi.object({
     pay: joi
       .object({


### PR DESCRIPTION
Under these changes this `notarial-api` web hook will be removed and instead called from within the [Orbit service](https://github.com/UKForeignOffice/case-management-v2).

It will attempt to extract the form submission reference in the order:
1. `metadata.externalReference` - the Orbit case ID if the submission there was successful
2. `metadata.internalReference` - the database record UUID
3. `metadata.pay.reference` - the Gov.Pay payment reference
4. a randomly generated reference

If `metadata.externalReference` is present and not `null` it indicates a successful submission to Orbit so the case team will not be emailed. Users (applicants) will continue to be emailed in all cases and using the reference as above so their application can be identified by FCDO staff.