### PR TITLE
NR-869: Update Standard Affirmation Email Template for Beta Service

### DIFF
--- a/api/.jest/setEnvVars.ts
+++ b/api/.jest/setEnvVars.ts
@@ -7,6 +7,7 @@ process.env.PAY_ACCOUNT_TRANSACTIONS_URL = "https://selfservice.payments.service
 process.env.SUBMISSION_EMAIL_ADDRESS = "pye@cautionyourblast.com";
 process.env.POST_EMAILS = '{"the British Embassy Tirana": "pye+albania@cautionyourblast.com", "the British Embassy Rome": "pye+rome@cautionyourblast.com"}';
 process.env.NOTIFY_TEMPLATE_AFFIRMATION_USER_CONFIRMATION = "ABC";
+process.env.NOTIFY_TEMPLATE_AFFIRMATION_USER_CONFIRMATION_SIMPLIFIED = "ABC";
 process.env.NOTIFY_TEMPLATE_CNI_USER_CONFIRMATION = "ABC";
 process.env.NOTIFY_TEMPLATE_CNI_USER_POSTAL_CONFIRMATION = "ABC";
 process.env.NOTIFY_TEMPLATE_EXCHANGE_USER_CONFIRMATION = "ABC";

--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -5,6 +5,7 @@
   "Notify": {
     "Template": {
       "affirmationUserConfirmation": "NOTIFY_TEMPLATE_AFFIRMATION_USER_CONFIRMATION",
+      "affirmationUserConfirmationSimplified": "NOTIFY_TEMPLATE_AFFIRMATION_USER_CONFIRMATION_SIMPLIFIED",
       "cniUserConfirmation": "NOTIFY_TEMPLATE_CNI_USER_CONFIRMATION",
       "cniUserPostalConfirmation": "NOTIFY_TEMPLATE_CNI_USER_POSTAL_CONFIRMATION",
       "exchangeUserConfirmation": "NOTIFY_TEMPLATE_EXCHANGE_USER_CONFIRMATION",

--- a/api/src/middlewares/services/SubmitService/SubmitService.ts
+++ b/api/src/middlewares/services/SubmitService/SubmitService.ts
@@ -68,7 +68,7 @@ export class SubmitService {
         this.logger.info({reference, caseProcessJob}, `SES_PROCESS job queued successfully for ${reference}`);
       }
 
-      const userProcessJob = await this.userService.sendToProcessQueue(answers, { reference, payment: metadata.pay, type, postal: metadata.postal });
+      const userProcessJob = await this.userService.sendToProcessQueue(answers, { reference, payment: metadata.pay, type, postal: metadata.postal, source: metadata.source });
 
       this.logger.info({ reference, userProcessJob }, `NOTIFY_PROCESS job queued successfully for ${reference}`);
     } catch (e) {

--- a/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
+++ b/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
@@ -8,15 +8,24 @@ import { UserTemplateGroup } from "./UserTemplateGroup";
 
 export class MarriageUserTemplates implements UserTemplateGroup {
   templates: {
-    affirmation: Record<PostalVariant, string>;
+    affirmation: {
+      simplified: Record<PostalVariant, string>;
+      legacy: Record<PostalVariant, string>;
+    };
     exchange: Record<PostalVariant, string>;
     cni: Record<CNISubGroup, Record<PostalVariant, string>>;
   };
   constructor() {
     this.templates = {
       affirmation: {
-        inPerson: config.get<string>("Notify.Template.affirmationUserConfirmation"),
-        postal: config.get<string>("Notify.Template.affirmationUserConfirmation"),
+        simplified: {
+          inPerson: config.get<string>("Notify.Template.affirmationUserConfirmationSimplified"),
+          postal: config.get<string>("Notify.Template.affirmationUserConfirmationSimplified"),
+        },
+        legacy: {
+          inPerson: config.get<string>("Notify.Template.affirmationUserConfirmation"),
+          postal: config.get<string>("Notify.Template.affirmationUserConfirmation"),
+        },
       },
       cni: {
         cni: {
@@ -39,7 +48,7 @@ export class MarriageUserTemplates implements UserTemplateGroup {
     };
   }
 
-  getTemplate(data: { answers: AnswersHashMap; metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean } }) {
+  getTemplate(data: { answers: AnswersHashMap; metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean; source?: string } }) {
     const { answers, metadata } = data;
     const { type } = data.metadata;
 
@@ -51,13 +60,31 @@ export class MarriageUserTemplates implements UserTemplateGroup {
     if (type === "cni") {
       const serviceSubtype = (answers.service ?? "cni") as MarriageFormType;
       template = this.templates.cni[serviceSubtype][postalVariant];
+    } else if (type === "affirmation") {
+      const isSimplified = metadata.source === "simplified-marriage-v1";
+      template = this.templates.affirmation[isSimplified ? "simplified" : "legacy"][postalVariant];
+    } else {
+      template = this.templates.exchange[postalVariant];
     }
-
-    template ??= this.templates[type][postalVariant];
 
     const personalisationBuilder = getPersonalisationBuilder(type);
 
-    builder ??= personalisationBuilder[postalVariant];
+    builder = personalisationBuilder[postalVariant];
+
+    // Only the simplified affirmation template uses a `duration` placeholder.
+    // Wrap the shared builder to append it without affecting other templates.
+    if (type === "affirmation" && metadata.source === "simplified-marriage-v1") {
+      const baseBuilder = builder;
+      builder = (answers: AnswersHashMap, meta: { reference: string; payment?: PayMetadata; type?: FormType }) => {
+        const personalisation = baseBuilder(answers, meta);
+        const country = answers.country as string;
+        const countryContext = additionalContexts.marriage.countries[country];
+        return {
+          ...personalisation,
+          duration: countryContext?.duration || "3 months",
+        };
+      };
+    }
 
     return {
       template,

--- a/api/src/middlewares/services/UserService/NotifyTemplates/UserTemplateGroup.ts
+++ b/api/src/middlewares/services/UserService/NotifyTemplates/UserTemplateGroup.ts
@@ -3,7 +3,7 @@ import { FormType, PayMetadata } from "../../../../types/FormDataBody";
 
 type getTemplateParams = {
   answers: AnswersHashMap;
-  metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean };
+  metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean; source?: string };
 };
 
 type Builder = (

--- a/api/src/middlewares/services/UserService/NotifyTemplates/UserTemplates.ts
+++ b/api/src/middlewares/services/UserService/NotifyTemplates/UserTemplates.ts
@@ -25,7 +25,7 @@ export class UserTemplates {
     }
   }
 
-  getTemplate(data: { answers: AnswersHashMap; metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean } }) {
+  getTemplate(data: { answers: AnswersHashMap; metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean; source?: string } }) {
     const { type } = data.metadata;
 
     if (this.isMarriageFormType(type)) {

--- a/api/src/middlewares/services/UserService/UserService.ts
+++ b/api/src/middlewares/services/UserService/UserService.ts
@@ -19,11 +19,11 @@ export class UserService {
   /**
    * Stores the user's answers in the queue for processing.
    */
-  async sendToProcessQueue(answers: AnswersHashMap, metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean }) {
+  async sendToProcessQueue(answers: AnswersHashMap, metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean; source?: string }) {
     return await this.queueService.sendToQueue("NOTIFY_PROCESS", { answers, metadata });
   }
 
-  async sendEmailToUser(data: { answers: AnswersHashMap; metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean } }) {
+  async sendEmailToUser(data: { answers: AnswersHashMap; metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean; source?: string } }) {
     const { answers, metadata } = data;
     const { reference } = metadata;
 

--- a/api/src/middlewares/services/UserService/__tests__/userService.test.ts
+++ b/api/src/middlewares/services/UserService/__tests__/userService.test.ts
@@ -5,6 +5,7 @@ jest.mock("config", () => ({
   get(setting) {
     const templates = {
       "Notify.Template.affirmationUserConfirmation": "affirmation-template",
+      "Notify.Template.affirmationUserConfirmationSimplified": "affirmation-simplified-template",
       "Notify.Template.cniUserConfirmation": "cni-template",
       "Notify.Template.cniUserPostalConfirmation": "cni-postal-template",
       "Notify.Template.mscUserConfirmation": "msc-template",
@@ -47,8 +48,9 @@ beforeEach(() => {
 
 describe("sendEmailToUser - Marriage templates", () => {
   test.each`
-    label                                         | answers                     | metadata                               | template
-    ${"affirmation"}                              | ${{}}                       | ${{ type: "affirmation" }}             | ${"affirmation-template"}
+    label                                         | answers                     | metadata                                                              | template
+    ${"affirmation - legacy"}                     | ${{}}                       | ${{ type: "affirmation" }}                                            | ${"affirmation-template"}
+    ${"affirmation - simplified"}                 | ${{}}                       | ${{ type: "affirmation", source: "simplified-marriage-v1" }}          | ${"affirmation-simplified-template"}
     ${"exchange - inPerson"}                      | ${{}}                       | ${{ type: "exchange" }}                | ${"exchange-template"}
     ${"exchange - postal"}                        | ${{}}                       | ${{ type: "exchange", postal: true }}  | ${"exchange-postal-template"}
     ${"exchange - croatia"}                       | ${{ country: "Croatia" }}   | ${{ type: "exchange" }}                | ${"exchange-template"}

--- a/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder/marriage/inPerson/getAdditionalPersonalisations.ts
+++ b/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder/marriage/inPerson/getAdditionalPersonalisations.ts
@@ -9,9 +9,13 @@ export const personalisationTypeMap: Record<MarriageFormType, PersonalisationFun
   exchange: getExchangePersonalisations,
 };
 
+function hasNoPreviousMarriage(maritalStatus: unknown) {
+  return maritalStatus === "Never married" || maritalStatus === "Single";
+}
+
 export function getAffirmationPersonalisations(fields: AnswersHashMap) {
   return {
-    previouslyMarried: fields.maritalStatus !== "Never married",
+    previouslyMarried: !hasNoPreviousMarriage(fields.maritalStatus),
     religious: fields.oathType === "Religious",
   };
 }
@@ -20,7 +24,7 @@ export function getCNIPersonalisations(fields: AnswersHashMap) {
   return {
     livesInCountry: fields.livesInCountry === true,
     livesAbroad: !fields.livesInCountry,
-    previouslyMarried: fields.maritalStatus !== "Never married",
+    previouslyMarried: !hasNoPreviousMarriage(fields.maritalStatus),
     religious: fields.oathType === "Religious",
     croatiaCertNeeded: fields.certRequired === true,
     countryIsItaly: fields.country === "Italy",

--- a/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder/marriage/postal/index.ts
+++ b/api/src/middlewares/services/UserService/personalisation/PersonalisationBuilder/marriage/postal/index.ts
@@ -21,7 +21,7 @@ export function buildPostalPersonalisation(answers: AnswersHashMap, metadata: { 
   const isSuccessfulPayment = metadata.payment?.state?.status === "success";
   const country = answers["country"] as string;
   const post = answers["post"] as string;
-  const userHadPreviousMarriage = answers.maritalStatus !== "Never married";
+  const userHadPreviousMarriage = answers.maritalStatus !== "Never married" && answers.maritalStatus !== "Single";
 
   const additionalContext = getPostalAdditionalContext(country, post);
   const personalisationType = getAdditionalPersonalisationsType(answers, metadata.type);

--- a/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
+++ b/api/src/middlewares/services/UserService/personalisation/__tests__/PersonalisationBuilder.test.ts
@@ -172,6 +172,18 @@ test("getAffirmationPersonalisations returns the correct personalisations given 
   });
 });
 
+test("getAffirmationPersonalisations treats simplified 'Single' as not previously married", () => {
+  const answers = {
+    maritalStatus: "Single",
+    oathType: "Non-religious",
+  };
+
+  expect(getAffirmationPersonalisations(answers)).toStrictEqual({
+    previouslyMarried: false,
+    religious: false,
+  });
+});
+
 test("getCNIPersonalisations returns the correct personalisations given all positive answers", () => {
   const answers = {
     livesInCountry: true,
@@ -208,6 +220,17 @@ test("getCNIPersonalisations returns the correct personalisations given all nega
     religious: false,
     countryIsItaly: false,
   });
+});
+
+test("buildPostalPersonalisation treats simplified 'Single' as no previous marriage", () => {
+  const answers = {
+    ...marriageAnswers,
+    maritalStatus: "Single",
+  };
+
+  const personalisation = buildPostalPersonalisation(answers, { reference: "1234", type: "cni" });
+
+  expect(personalisation.userHadPreviousMarriage).toBe(false);
 });
 
 test("buildJobData should return the correct personalisation for a certify a copy in-person email", () => {

--- a/worker/src/queues/notify/workers/notifyProcessHandler.ts
+++ b/worker/src/queues/notify/workers/notifyProcessHandler.ts
@@ -16,7 +16,7 @@ const logger = pino().child({
 const CREATE_NOTIFY_EMAIL_URL = config.get<string>("NotarialApi.createNotifyEmailUrl");
 type NotifyParseJob = {
   answers: any;
-  metadata: { reference: string; payment?: PayMetadata; type: string };
+  metadata: { reference: string; payment?: PayMetadata; type: string; source?: string };
 };
 /**
  * When a "NOTIFY_PARSE" event is detected, this worker simply POSTs the data back to the notarial-api/forms/emails/user


### PR DESCRIPTION
- JIRA: https://consular.atlassian.net/browse/NR-869?atlOrigin=eyJpIjoiZjk0ZGQyNTVmMmY2NDQxYWJhNmIzNTRlNmU0ZDU4NDgiLCJwIjoiaiJ9
- NR-869: Added simplified affirmation email template with conditional selection based on `metadata.source`
- Duration personalisation: Added country-specific duration field to simplified affirmation emails with "3 months" fallback

**Build:**
<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/2b63dcf8-d6ff-4339-8637-236f59404a6f" />

