### PR TITLE
NR-869: Add previous names to email template

### DIFF
--- a/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
+++ b/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
@@ -8,15 +8,24 @@ import { UserTemplateGroup } from "./UserTemplateGroup";
 
 export class MarriageUserTemplates implements UserTemplateGroup {
   templates: {
-    affirmation: Record<PostalVariant, string>;
+    affirmation: {
+      simplified: Record<PostalVariant, string>;
+      legacy: Record<PostalVariant, string>;
+    };
     exchange: Record<PostalVariant, string>;
     cni: Record<CNISubGroup, Record<PostalVariant, string>>;
   };
   constructor() {
     this.templates = {
       affirmation: {
-        inPerson: config.get<string>("Notify.Template.affirmationUserConfirmation"),
-        postal: config.get<string>("Notify.Template.affirmationUserConfirmation"),
+        simplified: {
+          inPerson: config.get<string>("Notify.Template.affirmationUserConfirmationSimplified"),
+          postal: config.get<string>("Notify.Template.affirmationUserConfirmationSimplified"),
+        },
+        legacy: {
+          inPerson: config.get<string>("Notify.Template.affirmationUserConfirmation"),
+          postal: config.get<string>("Notify.Template.affirmationUserConfirmation"),
+        },
       },
       cni: {
         cni: {
@@ -39,7 +48,7 @@ export class MarriageUserTemplates implements UserTemplateGroup {
     };
   }
 
-  getTemplate(data: { answers: AnswersHashMap; metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean } }) {
+  getTemplate(data: { answers: AnswersHashMap; metadata: { reference: string; payment?: PayMetadata; type: FormType; postal?: boolean; source?: string } }) {
     const { answers, metadata } = data;
     const { type } = data.metadata;
 
@@ -51,13 +60,34 @@ export class MarriageUserTemplates implements UserTemplateGroup {
     if (type === "cni") {
       const serviceSubtype = (answers.service ?? "cni") as MarriageFormType;
       template = this.templates.cni[serviceSubtype][postalVariant];
+    } else if (type === "affirmation") {
+      const isSimplified = metadata.source === "simplified-marriage-v1";
+      template = this.templates.affirmation[isSimplified ? "simplified" : "legacy"][postalVariant];
+    } else {
+      template = this.templates.exchange[postalVariant];
     }
-
-    template ??= this.templates[type][postalVariant];
 
     const personalisationBuilder = getPersonalisationBuilder(type);
 
-    builder ??= personalisationBuilder[postalVariant];
+    builder = personalisationBuilder[postalVariant];
+
+    // Only the simplified affirmation template uses a `duration` placeholder.
+    // Wrap the shared builder to append it without affecting other templates.
+    if (type === "affirmation" && metadata.source === "simplified-marriage-v1") {
+      const baseBuilder = builder;
+      builder = (answers: AnswersHashMap, meta: { reference: string; payment?: PayMetadata; type?: FormType }) => {
+        const personalisation = baseBuilder(answers, meta);
+        const country = answers.country as string;
+        const countryContext = additionalContexts.marriage.countries[country];
+        const hasPreviousNameByDeedPoll = this.hasSimplifiedPreviousNameStatus(answers.nameChangedByDeedPoll);
+        const hasPreviousNameByMarriage = this.hasSimplifiedPreviousNameStatus(answers.nameChangedByMarriage);
+        return {
+          ...personalisation,
+          duration: countryContext?.duration || "3 months",
+          previousNames: hasPreviousNameByDeedPoll || hasPreviousNameByMarriage,
+        };
+      };
+    }
 
     return {
       template,
@@ -75,5 +105,14 @@ export class MarriageUserTemplates implements UserTemplateGroup {
     const postalSupport = postal ?? (type === "exchange" && countryOffersPostalRoute && !countryIsCroatia);
 
     return postalSupport ? "postal" : "inPerson";
+  }
+
+  private hasSimplifiedPreviousNameStatus(value: string | boolean | undefined) {
+    if (typeof value !== "string") {
+      return false;
+    }
+
+    const normalised = value.trim().toLowerCase();
+    return normalised === "once" || normalised === "name changed more than once";
   }
 }

--- a/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
+++ b/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
@@ -115,8 +115,7 @@ export class MarriageUserTemplates implements UserTemplateGroup {
     const normalised = value.trim().toLowerCase();
     return (
       normalised === "once" ||
-      normalised === "name changed more than once" ||
-      normalised === "yesmorethanonce"
+      normalised === "name changed more than once"
     );
   }
 }

--- a/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
+++ b/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
@@ -115,7 +115,8 @@ export class MarriageUserTemplates implements UserTemplateGroup {
     const normalised = value.trim().toLowerCase();
     return (
       normalised === "once" ||
-      normalised === "name changed more than once"
+      normalised === "name changed more than once" ||
+      normalised === "yesmorethanonce"
     );
   }
 }

--- a/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
+++ b/api/src/middlewares/services/UserService/NotifyTemplates/MarriageUserTemplates.ts
@@ -113,6 +113,10 @@ export class MarriageUserTemplates implements UserTemplateGroup {
     }
 
     const normalised = value.trim().toLowerCase();
-    return normalised === "once" || normalised === "name changed more than once";
+    return (
+      normalised === "once" ||
+      normalised === "name changed more than once" ||
+      normalised === "yesmorethanonce"
+    );
   }
 }

--- a/api/src/middlewares/services/UserService/__tests__/userService.test.ts
+++ b/api/src/middlewares/services/UserService/__tests__/userService.test.ts
@@ -66,6 +66,64 @@ describe("sendEmailToUser - Marriage templates", () => {
       })
     );
   });
+
+  test("affirmation - simplified adds previousNames when either name-change path exists", async () => {
+    await userService.sendEmailToUser({
+      answers: {
+        firstName: "test",
+        emailAddress: "test@example.com",
+        country: "Italy",
+        nameChangedByMarriage: "name changed more than once",
+        nameChangedByDeedPoll: "false",
+        previousNameByMarriage: "No",
+        previousNameByDeedPoll: "No",
+      },
+      metadata: {
+        type: "affirmation",
+        source: "simplified-marriage-v1",
+        reference: "ref",
+      },
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          personalisation: expect.objectContaining({
+            previousNames: true,
+          }),
+        }),
+      })
+    );
+  });
+
+  test("affirmation - simplified does not add previousNames for explicit negative values", async () => {
+    await userService.sendEmailToUser({
+      answers: {
+        firstName: "test",
+        emailAddress: "test@example.com",
+        country: "Italy",
+        nameChangedByMarriage: "No",
+        nameChangedByDeedPoll: "false",
+        previousNameByMarriage: "No",
+        previousNameByDeedPoll: "Old Name",
+      },
+      metadata: {
+        type: "affirmation",
+        source: "simplified-marriage-v1",
+        reference: "ref",
+      },
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          personalisation: expect.objectContaining({
+            previousNames: false,
+          }),
+        }),
+      })
+    );
+  });
 });
 
 describe("sendEmailToUser - certifyCopy", () => {

--- a/api/src/middlewares/services/UserService/__tests__/userService.test.ts
+++ b/api/src/middlewares/services/UserService/__tests__/userService.test.ts
@@ -126,6 +126,33 @@ describe("sendEmailToUser - Marriage templates", () => {
       })
     );
   });
+
+  test("affirmation - simplified adds previousNames for deed poll YesMoreThanOnce", async () => {
+    await userService.sendEmailToUser({
+      answers: {
+        firstName: "test",
+        emailAddress: "test@example.com",
+        country: "Italy",
+        nameChangedByMarriage: "no",
+        nameChangedByDeedPoll: "YesMoreThanOnce",
+      },
+      metadata: {
+        type: "affirmation",
+        source: "simplified-marriage-v1",
+        reference: "ref",
+      },
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          personalisation: expect.objectContaining({
+            previousNames: true,
+          }),
+        }),
+      })
+    );
+  });
 });
 
 describe("sendEmailToUser - certifyCopy", () => {


### PR DESCRIPTION
- JIRA: https://consular.atlassian.net/browse/NR-869?atlOrigin=eyJpIjoiMDlkNjIwMDkzNjVhNGEyYWIwYzNhOTM3YTE4MGVjYmQiLCJwIjoiaiJ9
- Changes to support content for previous names in GOV Notify
- Affects Beta service only